### PR TITLE
Clean up README, add demo submission, switch to Apache 2.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,131 +1,191 @@
-# PolyForm Noncommercial License 1.0.0
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-## Acceptance
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-In order to get any license under these terms, you must agree
-to them as both strict obligations and conditions to all
-your licenses.
+   1. Definitions.
 
-## Copyright License
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-The licensor grants you a copyright license for the
-software to do everything you might do with the software
-that would otherwise infringe the licensor's copyright
-in it for any permitted purpose.  However, you may
-only distribute the software according to [Distribution
-License](#distribution-license) and make changes or new works
-based on the software according to [Changes and New Works
-License](#changes-and-new-works-license).
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-## Distribution License
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-The licensor grants you an additional copyright license
-to distribute copies of the software.  Your license
-to distribute covers distributing the software with
-changes and new works permitted by [Changes and New Works
-License](#changes-and-new-works-license).
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-## Notices
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-You must ensure that anyone who gets a copy of any part of
-the software from you also gets a copy of these terms or the
-URL for them above, as well as copies of any plain-text lines
-beginning with `Required Notice:` that the licensor provided
-with the software.  For example:
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-## Changes and New Works License
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-The licensor grants you an additional copyright license to
-make changes and new works based on the software for any
-permitted purpose.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-## Patent License
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
 
-The licensor grants you a patent license for the software that
-covers patent claims the licensor can license, or becomes able
-to license, that you would infringe by using the software.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-## Noncommercial Purposes
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-Any noncommercial purpose is a permitted purpose.
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-## Personal Uses
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-Personal use for research, experiment, and testing for
-the benefit of public knowledge, personal study, private
-entertainment, hobby projects, amateur pursuits, or religious
-observance, without any anticipated commercial application,
-is use for a permitted purpose.
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-## Noncommercial Organizations
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-Use by any charitable organization, educational institution,
-public research organization, public safety or health
-organization, environmental protection organization,
-or government institution is use for a permitted purpose
-regardless of the source of funding or obligations resulting
-from the funding.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-## Fair Use
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-You may have "fair use" rights for the software under the
-law. These terms do not limit them.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-## No Other Rights
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-These terms do not allow you to sublicense or transfer any of
-your licenses to anyone else, or prevent the licensor from
-granting licenses to anyone else.  These terms do not imply
-any other licenses.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-## Patent Defense
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-If you make any written claim that the software infringes or
-contributes to infringement of any patent, your patent license
-for the software granted under these terms ends immediately. If
-your company makes such a claim, your patent license ends
-immediately for work on behalf of your company.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-## Violations
+   END OF TERMS AND CONDITIONS
 
-The first time you are notified in writing that you have
-violated any of these terms, or done anything with the software
-not covered by your licenses, your licenses can nonetheless
-continue if you come into full compliance with these terms,
-and take practical steps to correct past violations, within
-32 days of receiving notice.  Otherwise, all your licenses
-end immediately.
+   Copyright 2025 Partcl, Inc.
 
-## No Liability
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-***As far as the law allows, the software comes as is, without
-any warranty or condition, and the licensor will not be liable
-to you for any damages arising out of these terms or the use
-or nature of the software, under any kind of legal claim.***
+       http://www.apache.org/licenses/LICENSE-2.0
 
-## Definitions
-
-The **licensor** is the individual or entity offering these
-terms, and the **software** is the software the licensor makes
-available under these terms.
-
-**You** refers to the individual or entity agreeing to these
-terms.
-
-**Your company** is any legal entity, sole proprietorship,
-or other kind of organization that you work for, plus all
-organizations that have control over, are under the control of,
-or are under common control with that organization.  **Control**
-means ownership of substantially all the assets of an entity,
-or the power to direct its management and policies by vote,
-contract, or otherwise.  Control can be direct or indirect.
-
-**Your licenses** are all the licenses granted to you for the
-software under these terms.
-
-**Use** means anything you do with the software requiring one
-of your licenses.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ For example, the **ibm01** benchmark has:
 
 ## 🏆 Prizes
 
-- **$20,000 — First Place (Grand Prize):** Awarded to the top submission by proxy score that surpasses the Simulated Annealing (SA) and RePlAce baselines for WNS, TNS, and Area reported in [An Updated Assessment of Reinforcement Learning for Macro Placement]([https://arxiv.org/pdf/2302.11014](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=11300304)) for NG45.  
-- **$10,000 — First Place (Alternate):** Awarded if the winning submission ranks first overall for proxy score but does **not** exceed the SA and RePlAce benchmark results for WNS, TNS, and Area.  
-- **$5,000 — Second Place:** Awarded to the runner-up based on final competition rankings.  
+- **$20,000 — Grand Prize:** The top 7 submissions by proxy score are evaluated through the OpenROAD flow on NG45 designs (including hidden designs). Among those 7, the submission that beats the SA and RePlAce baselines (reported in [An Updated Assessment of Reinforcement Learning for Macro Placement](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=11300304)) by the largest margin on WNS, TNS, and Area wins the Grand Prize.
+- **$10,000 — First Place (Proxy):** Awarded to the #1 submission by proxy score. Only awarded if no submission qualifies for the Grand Prize.
+- **$5,000 — Second Place:** Awarded to the runner-up of the Grand Prize. If no submission qualifies for the Grand Prize, awarded to the #2 submission by proxy score.
 - **$4,000 — Innovation Award:** Granted to the most creative or technically innovative approach among the top entries, as determined by the judging panel.
 - **Swag:** Every valid submission gets HRT swag!
 
@@ -39,16 +39,51 @@ For example, the **ibm01** benchmark has:
 - All submissions will be via google form. Submissions may be made public or private before the end of judging.
 - Private submissions will be required to share repository with judges so they may clone/evaluate the method.
 - Teams may be up to 5 individuals.
-- The deadline for submissions is 10 weeks from the posting of the competition at 11:59PM PT WILL INSERT DEADLINE DATE.
+- The deadline for submissions is May 4, 2026, 11:59 pacific.
 - All teams may only submit one algorithm.
 - **All winning implementations must be made open-source under Apache 2.0 or GPL**
 
+## Additional Rules
+
+### Allowed
+
+1. **Any algorithmic approach**: SA, RL, GNN, analytical methods, hybrid approaches, learning-based, etc.
+2. **Any framework**: PyTorch, TensorFlow, JAX, or pure Python/C++
+3. **Any optimization technique**: Gradient descent, evolutionary algorithms, local search, etc.
+4. **Training on public benchmarks**: You can learn from the IBM benchmark data
+
+### Not Allowed
+
+1. ❌ Modifying the evaluation functions (must use TILOS MacroPlacement evaluator as-is)
+2. ❌ Hardcoding solutions for specific benchmarks (must be general algorithm)
+3. ❌ Using external/proprietary placement tools (must be open-source submission)
+4. ❌ Exceeding runtime limits (1 hour per benchmark hard timeout)
+
+### Runtime Constraints
+
+- **Soft limit**: 5 minutes per benchmark (no penalty)
+- **Penalty zone**: 5-60 minutes (linear penalty up to -0.1 quality score)
+- **Hard timeout**: 1 hour (automatic disqualification)
+
 ## Evaluation Details
 
-- Benchmark numbers are in this paper: [An Updated Assessment of Reinforcement Learning for Macro Placement](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=11300304)
-- We will judge the top 5 submissions ranked by proxy score. We will run the OpenROAD flow on these submissions to judge that submission methods generalize to full PnR flows.
-- You must be within 5% of the nangate45 Innovus results for WNS, TNS, Area when evaluated with the OpenROAD flow for the Simulated Annealing and RePlAce. You must also be pareto-optimal in runtime to get the grand prize. 
-- To avoid overfitting, we will also evaluate submissions on 1~2 hidden designs with the OpenROAD flow backend.
+Evaluation is two-tiered:
+
+### Tier 1: Proxy Cost Ranking (All Submissions)
+
+All submissions are ranked by **proxy cost** across the 18 IBM benchmarks. This is the primary qualifying metric. Proxy cost is computed using the TILOS MacroPlacement evaluator:
+
+> **Proxy Cost = 1.0 × Wirelength + 0.5 × Density + 0.5 × Congestion**
+
+Baseline numbers are from: [An Updated Assessment of Reinforcement Learning for Macro Placement](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=11300304)
+
+### Tier 2: OpenROAD Flow Validation (Top Submissions)
+
+The top 7 submissions by proxy score will be evaluated through the full **OpenROAD flow** on NG45 designs to measure real PnR outcomes: **WNS, TNS, and Area**.
+
+- The **Grand Prize ($20K)** is awarded based on best OpenROAD results among these top submissions.
+- To qualify, you must surpass the SA and RePlAce baselines for WNS, TNS, and Area.
+- To avoid overfitting, we will also evaluate on 1-2 hidden NG45 designs.
 
 
 
@@ -77,160 +112,23 @@ pytest
 ### Run Your First Example
 
 ```bash
-# Run the simple random placer example
-python submissions/examples/simple_random_placer.py
+# Run the greedy row placer on ibm01
+python submissions/examples/greedy_row_placer.py
+
+# Run on all 17 IBM benchmarks
+python submissions/examples/greedy_row_placer.py --all
 ```
 
-You should see output like:
+Running on all benchmarks produces a summary like:
 ```
-[4/4] Computing proxy cost and overlap metrics...
-  ✓ Costs computed:
-    - Wirelength:  0.128768
-    - Density:     1.276113
-    - Congestion:  2.248285
-    - Proxy Cost:  1.890967 ⭐
-
-  ✓ Overlap analysis:
-    - Overlapping pairs:       211
-    - Macros with overlaps:    198 (80.5%)
-    - Total overlap area:      99.632 μm²
-
-Comparison with initial placement:
-  Initial proxy cost:   1.038498 (overlaps: 9)
-  Random proxy cost:    1.890967 (overlaps: 211)
-  Score: -1000 (DISQUALIFIED: 211 overlaps)
+Benchmark     Proxy        SA   RePlAce     vs SA  vs RePlAce  Overlaps
+   ibm01    2.0463    1.3166    0.9976    -55.4%     -105.1%         0
+   ibm02    2.0431    1.9072    1.8370     -7.1%      -11.2%         0
+   ...
+     AVG    2.2109    2.1251    1.4578     -4.0%      -51.7%         0
 ```
 
-The random placer has overlaps and is automatically disqualified - your job is to do better!
-
-## 🎓 How It Works
-
-### 1. Benchmark Representation
-
-Benchmarks are represented as **PyTorch tensors** for easy integration with ML approaches:
-
-```python
-from loader import load_benchmark_from_dir
-
-# Load a benchmark
-benchmark, plc = load_benchmark_from_dir('external/MacroPlacement/Testcases/ICCAD04/ibm01')
-
-print(f"Benchmark: {benchmark.name}")
-print(f"Macros: {benchmark.num_macros}")
-print(f"Nets: {benchmark.num_nets}")
-print(f"Canvas: {benchmark.canvas_width} × {benchmark.canvas_height} μm")
-
-# Access data
-print(f"Macro positions: {benchmark.macro_positions.shape}")  # [246, 2]
-print(f"Macro sizes: {benchmark.macro_sizes.shape}")          # [246, 2]
-print(f"Fixed macros: {benchmark.macro_fixed.shape}")         # [246] (bool)
-```
-
-### 2. Implementing Your Placer
-
-Create a class with a `.place()` method:
-
-```python
-import torch
-from benchmark import Benchmark
-
-class MyPlacer:
-    def place(self, benchmark: Benchmark) -> torch.Tensor:
-        """
-        Generate macro placement.
-
-        Args:
-            benchmark: Benchmark object with:
-                - num_macros: Number of macros (246 for ibm01)
-                - macro_sizes: [num_macros, 2] (width, height) in μm
-                - macro_fixed: [num_macros] bool (True if fixed)
-                - canvas_width, canvas_height: Canvas dimensions
-                - num_nets: Number of nets (7269 for ibm01)
-
-        Returns:
-            placement: [num_macros, 2] tensor of (x, y) center positions
-        """
-        placement = torch.zeros(benchmark.num_macros, 2)
-
-        # Your algorithm here!
-        # - Use GNNs, RL, SA, optimization, or any approach
-        # - MUST have zero overlaps (automatic disqualification otherwise)
-        # - MUST be within canvas boundaries
-        # - Minimize proxy cost while keeping runtime reasonable
-
-        # Remember to respect fixed macros!
-        fixed_mask = benchmark.macro_fixed
-        placement[fixed_mask] = benchmark.macro_positions[fixed_mask]
-
-        return placement
-```
-
-### 3. Evaluation
-
-```python
-import time
-from loader import load_benchmark_from_dir
-from objective import compute_proxy_cost
-from utils import validate_placement
-
-# Load benchmark
-benchmark, plc = load_benchmark_from_dir('external/MacroPlacement/Testcases/ICCAD04/ibm01')
-
-# Run your placer with timing
-start_time = time.time()
-placer = MyPlacer()
-placement = placer.place(benchmark)
-runtime = time.time() - start_time
-
-# Validate placement legality
-is_valid, violations = validate_placement(placement, benchmark)
-if not is_valid:
-    print(f"Invalid placement: {violations}")
-
-# Compute cost and overlap metrics
-costs = compute_proxy_cost(placement, benchmark, plc)
-print(f"Proxy cost: {costs['proxy_cost']:.6f}")
-print(f"Overlaps: {costs['overlap_count']} pairs")
-print(f"Runtime: {runtime:.2f}s")
-
-# Compute score
-if costs['overlap_count'] > 0:
-    score = -1000  # Disqualified
-else:
-    baseline_cost = 1.0  # Replace with actual baseline
-    quality = (baseline_cost - costs['proxy_cost']) / baseline_cost
-    runtime_penalty = max(0, (runtime - 300) / 300)
-    score = quality - 0.1 * runtime_penalty
-
-print(f"Score: {score}")
-```
-
-## 📋 Competition Rules
-
-### Allowed
-
-1. **Any algorithmic approach**: SA, RL, GNN, analytical methods, hybrid approaches, learning-based, etc.
-2. **Any framework**: PyTorch, TensorFlow, JAX, or pure Python/C++
-3. **Any optimization technique**: Gradient descent, evolutionary algorithms, local search, etc.
-4. **Training on public benchmarks**: You can learn from the IBM benchmark data
-
-### Not Allowed
-
-1. ❌ Modifying the evaluation functions (must use TILOS MacroPlacement evaluator as-is)
-2. ❌ Hardcoding solutions for specific benchmarks (must be general algorithm)
-3. ❌ Using external/proprietary placement tools (must be open-source submission)
-4. ❌ Exceeding runtime limits (1 hour per benchmark hard timeout)
-
-### Runtime Constraints
-
-- **Soft limit**: 5 minutes per benchmark (no penalty)
-- **Penalty zone**: 5-60 minutes (linear penalty up to -0.1 quality score)
-- **Hard timeout**: 1 hour (automatic disqualification)
-
-Runtime measured on standard hardware:
-- CPU: AMD EPYC 7763 (64 cores) or equivalent
-- RAM: 256GB
-- No GPU acceleration in evaluation (but you can use GPU during development)
+The greedy placer achieves zero overlaps but makes no attempt to optimize wirelength or connectivity — your job is to do better! See [`SETUP.md`](SETUP.md) for the full API reference and [`submissions/examples/`](submissions/examples/) for working examples.
 
 ### Overlap Tolerance: ZERO
 
@@ -273,7 +171,7 @@ Each benchmark includes:
 **Baseline Analysis:**
 - RePlAce (⭐) consistently outperforms SA across all benchmarks
 - RePlAce achieves 15-55% lower proxy cost than SA
-- **To win the $20K prize, you must beat RePlAce (the stronger baseline) on aggregate**
+- **To qualify for the Grand Prize, your placement must also produce better WNS, TNS, and Area than both baselines when evaluated through the OpenROAD flow on NG45 designs**
 - Both baselines achieve zero overlaps (enforced as hard constraint)
 
 ## 💡 Why This Is Hard
@@ -292,9 +190,8 @@ Classical methods (SA, RePlAce) have been refined for decades but still have roo
 
 ## 📖 Documentation
 
-- **Setup Guide**: [`SETUP.md`](SETUP.md) - Infrastructure details, testing, cost computation
-- **API Reference**: [`SETUP.md`](SETUP.md) - Benchmark format, loader, objective functions
-- **Example Submissions**: [`submissions/examples/`](submissions/examples/) - Random placer example
+- **Setup & API Reference**: [`SETUP.md`](SETUP.md) - Infrastructure details, benchmark format, cost computation, testing
+- **Example Submissions**: [`submissions/examples/`](submissions/examples/) - Working placer examples
 
 ## 📚 References
 
@@ -304,6 +201,18 @@ Classical methods (SA, RePlAce) have been refined for decades but still have roo
   - SA and RePlAce baseline implementations
 
 - **ICCAD04 Benchmarks**: Classic macro placement benchmark suite used in academic research
+
+## 🏅 Leaderboard
+
+Submissions are ranked by **average proxy cost** across all 18 IBM benchmarks (lower is better). Zero overlaps required on all benchmarks.
+
+| Rank | Team | Avg Proxy Cost | Best | Worst | Overlaps | Runtime |
+|------|------|---------------|------|-------|----------|---------|
+| — | RePlAce (baseline) | **1.4578** | 0.9976 | 1.8370 | 0 | — |
+| — | SA (baseline) | 2.1251 | 1.3166 | 3.6726 | 0 | — |
+| — | Greedy Row (demo) | 2.2109 | 1.6728 | 2.7696 | 0 | 0.3s |
+
+*Submit your results to appear on the leaderboard!*
 
 ## 🤔 FAQ
 
@@ -317,13 +226,13 @@ A: Real chip design requires practical algorithms. A solution that takes hours i
 A: GPU use is encouraged. We will evaluate implementations with a GPU >40GB VRAM and 100GB of RAM.
 
 **Q: What if I beat one baseline but not the other?**
-A: You must beat BOTH baselines on aggregate to win the prize. However, you'll still be recognized on the leaderboard.
+A: You must beat BOTH SA and RePlAce baselines on WNS, TNS, and Area to qualify for the Grand Prize. You can still win the Proxy or Innovation prizes regardless.
 
 **Q: Are there hidden test cases?**
-A: No. All 18 IBM benchmarks are public. The aggregate score across all 18 determines the winner.
+A: All 18 IBM benchmarks for proxy cost ranking are public. For the OpenROAD flow evaluation (Tier 2), we will also test on 1-2 hidden NG45 designs to ensure generalization.
 
 **Q: What counts as "beating" the baseline?**
-A: Your geometric mean score across all benchmarks must be positive (meaning on average you beat the baseline).
+A: For proxy cost (Tier 1), your aggregate score across all IBM benchmarks must be positive. For the Grand Prize (Tier 2), your OpenROAD results for WNS, TNS, and Area must surpass both SA and RePlAce baselines on NG45 designs.
 
 ## 📧 Contact
 
@@ -332,12 +241,4 @@ A: Your geometric mean score across all benchmarks must be positive (meaning on 
 
 ## 📄 License
 
-This project is licensed under the PolyForm Noncommercial License 1.0.0 - see [LICENSE.md](LICENSE.md) for details.
-
----
-
-**Ready to win $20,000?**
-
-Beat SA and RePlAce on the IBM benchmarks with zero overlaps and reasonable runtime!
-
-Good luck! 🚀
+This project is licensed under the Apache License 2.0 - see [LICENSE.md](LICENSE.md) for details.

--- a/submissions/examples/greedy_row_placer.py
+++ b/submissions/examples/greedy_row_placer.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Greedy Row Placer - Demo Submission
+
+A simple but legal placer that:
+1. Sorts macros by height (tallest first)
+2. Places them left-to-right in rows (like shelf packing)
+3. Guarantees zero overlaps and canvas boundary compliance
+
+This produces valid, scoreable placements but makes no attempt to
+optimize wirelength, density, or congestion. Use it as a starting
+point for your own algorithm.
+
+Usage:
+    python submissions/examples/greedy_row_placer.py
+    python submissions/examples/greedy_row_placer.py --benchmark ibm01
+    python submissions/examples/greedy_row_placer.py --all
+"""
+
+import sys
+import time
+import argparse
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+import torch
+from loader import load_benchmark_from_dir
+from objective import compute_proxy_cost
+from utils import validate_placement
+from benchmark import Benchmark
+
+
+class GreedyRowPlacer:
+    """
+    Greedy row-based (shelf packing) placement.
+
+    Places macros in rows from bottom to top, left to right,
+    sorted by descending height. Guarantees zero overlaps.
+    """
+
+    def place(self, benchmark: Benchmark) -> torch.Tensor:
+        placement = benchmark.macro_positions.clone()
+        movable = benchmark.get_movable_mask()
+        movable_indices = torch.where(movable)[0].tolist()
+
+        sizes = benchmark.macro_sizes
+        canvas_w = benchmark.canvas_width
+        canvas_h = benchmark.canvas_height
+
+        # Sort movable macros by height descending (shelf packing heuristic)
+        movable_indices.sort(key=lambda i: -sizes[i, 1].item())
+
+        # Small gap to avoid float32 touching-edge false overlaps
+        gap = 0.001
+
+        cursor_x = 0.0
+        cursor_y = 0.0
+        row_height = 0.0
+
+        for idx in movable_indices:
+            w = sizes[idx, 0].item()
+            h = sizes[idx, 1].item()
+
+            # Start new row if macro doesn't fit
+            if cursor_x + w > canvas_w:
+                cursor_x = 0.0
+                cursor_y += row_height + gap
+                row_height = 0.0
+
+            # Check if we've run out of vertical space
+            if cursor_y + h > canvas_h:
+                # Place at origin as fallback (will overlap but shouldn't happen
+                # if area utilization < 100%)
+                placement[idx, 0] = w / 2
+                placement[idx, 1] = h / 2
+                continue
+
+            # Place macro (positions are centers)
+            placement[idx, 0] = cursor_x + w / 2
+            placement[idx, 1] = cursor_y + h / 2
+
+            cursor_x += w + gap
+            row_height = max(row_height, h)
+
+        return placement
+
+
+BENCHMARKS = [
+    "ibm01", "ibm02", "ibm03", "ibm04", "ibm06", "ibm07", "ibm08", "ibm09",
+    "ibm10", "ibm11", "ibm12", "ibm13", "ibm14", "ibm15", "ibm16", "ibm17", "ibm18",
+]
+
+SA_BASELINES = {
+    "ibm01": 1.3166, "ibm02": 1.9072, "ibm03": 1.7401, "ibm04": 1.5037,
+    "ibm06": 2.5057, "ibm07": 2.0229, "ibm08": 1.9239, "ibm09": 1.3875,
+    "ibm10": 2.1108, "ibm11": 1.7111, "ibm12": 2.8261, "ibm13": 1.9141,
+    "ibm14": 2.2750, "ibm15": 2.3000, "ibm16": 2.2337, "ibm17": 3.6726,
+    "ibm18": 2.7755,
+}
+
+REPLACE_BASELINES = {
+    "ibm01": 0.9976, "ibm02": 1.8370, "ibm03": 1.3222, "ibm04": 1.3024,
+    "ibm06": 1.6187, "ibm07": 1.4633, "ibm08": 1.4285, "ibm09": 1.1194,
+    "ibm10": 1.5009, "ibm11": 1.1774, "ibm12": 1.7261, "ibm13": 1.3355,
+    "ibm14": 1.5436, "ibm15": 1.5159, "ibm16": 1.4780, "ibm17": 1.6446,
+    "ibm18": 1.7722,
+}
+
+
+def evaluate_benchmark(name: str, testcase_root: str) -> dict:
+    """Evaluate the placer on a single benchmark."""
+    benchmark_dir = f"{testcase_root}/{name}"
+    benchmark, plc = load_benchmark_from_dir(benchmark_dir)
+
+    placer = GreedyRowPlacer()
+
+    start = time.time()
+    placement = placer.place(benchmark)
+    runtime = time.time() - start
+
+    is_valid, violations = validate_placement(placement, benchmark)
+    costs = compute_proxy_cost(placement, benchmark, plc)
+
+    return {
+        "name": name,
+        "proxy_cost": costs["proxy_cost"],
+        "wirelength": costs["wirelength_cost"],
+        "density": costs["density_cost"],
+        "congestion": costs["congestion_cost"],
+        "overlaps": costs["overlap_count"],
+        "runtime": runtime,
+        "valid": is_valid,
+        "sa_baseline": SA_BASELINES.get(name),
+        "replace_baseline": REPLACE_BASELINES.get(name),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Greedy Row Placer - Demo Submission")
+    parser.add_argument("--benchmark", "-b", type=str, default=None,
+                        help="Run on a specific benchmark (e.g., ibm01)")
+    parser.add_argument("--all", "-a", action="store_true",
+                        help="Run on all 17 IBM benchmarks")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).parent.parent.parent
+    testcase_root = repo_root / "external" / "MacroPlacement" / "Testcases" / "ICCAD04"
+
+    if not testcase_root.exists():
+        print(f"Error: Testcases not found at {testcase_root}")
+        print("Run: git submodule update --init external/MacroPlacement")
+        sys.exit(1)
+
+    benchmarks_to_run = BENCHMARKS if args.all else [args.benchmark or "ibm01"]
+
+    print("=" * 80)
+    print("Greedy Row Placer - Demo Submission")
+    print("=" * 80)
+    print()
+
+    results = []
+    for name in benchmarks_to_run:
+        print(f"  {name}...", end=" ", flush=True)
+        result = evaluate_benchmark(name, str(testcase_root))
+        results.append(result)
+
+        status = "VALID" if result["overlaps"] == 0 else f"INVALID ({result['overlaps']} overlaps)"
+        print(f"proxy={result['proxy_cost']:.4f}  "
+              f"(wl={result['wirelength']:.3f} den={result['density']:.3f} cong={result['congestion']:.3f})  "
+              f"{status}  [{result['runtime']:.2f}s]")
+
+    if len(results) > 1:
+        print()
+        print("-" * 80)
+        print(f"{'Benchmark':>8}  {'Proxy':>8}  {'SA':>8}  {'RePlAce':>8}  {'vs SA':>8}  {'vs RePlAce':>10}  {'Overlaps':>8}")
+        print("-" * 80)
+        for r in results:
+            vs_sa = ((r["sa_baseline"] - r["proxy_cost"]) / r["sa_baseline"] * 100) if r["sa_baseline"] else 0
+            vs_rep = ((r["replace_baseline"] - r["proxy_cost"]) / r["replace_baseline"] * 100) if r["replace_baseline"] else 0
+            print(f"{r['name']:>8}  {r['proxy_cost']:>8.4f}  {r['sa_baseline']:>8.4f}  {r['replace_baseline']:>8.4f}  "
+                  f"{vs_sa:>+7.1f}%  {vs_rep:>+9.1f}%  {r['overlaps']:>8}")
+
+        avg_proxy = sum(r["proxy_cost"] for r in results) / len(results)
+        avg_sa = sum(r["sa_baseline"] for r in results) / len(results)
+        avg_rep = sum(r["replace_baseline"] for r in results) / len(results)
+        total_overlaps = sum(r["overlaps"] for r in results)
+        total_runtime = sum(r["runtime"] for r in results)
+
+        print("-" * 80)
+        print(f"{'AVG':>8}  {avg_proxy:>8.4f}  {avg_sa:>8.4f}  {avg_rep:>8.4f}  "
+              f"{(avg_sa - avg_proxy) / avg_sa * 100:>+7.1f}%  "
+              f"{(avg_rep - avg_proxy) / avg_rep * 100:>+9.1f}%  {total_overlaps:>8}")
+        print()
+        print(f"Total runtime: {total_runtime:.2f}s")
+        if total_overlaps > 0:
+            print(f"DISQUALIFIED: {total_overlaps} total overlaps across benchmarks")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Remove inline code examples from README (inaccurate, duplicated SETUP.md)
- Clarify two-tier evaluation: proxy cost ranking + ORFS validation for Grand Prize
- Fix GPU contradiction, baseline analysis text, documentation links
- Add leaderboard table with baselines and demo placer
- Replace PolyForm Noncommercial license with Apache 2.0
- Add greedy_row_placer.py: zero-overlap shelf-packing demo across all 17 IBM benchmarks