### PR TITLE
Fix overlap counting for soft macros + ORFS placement padding

### DIFF
--- a/macro_place/objective.py
+++ b/macro_place/objective.py
@@ -75,9 +75,10 @@ def compute_overlap_metrics(
     max_overlap_area = 0.0
     macros_with_overlaps = set()
 
-    # Check all pairs for overlap
-    for i in range(num_macros):
-        for j in range(i + 1, num_macros):
+    # Check hard macro pairs only for overlap (soft macros naturally overlap)
+    num_hard = getattr(benchmark, 'num_hard_macros', num_macros)
+    for i in range(num_hard):
+        for j in range(i + 1, num_hard):
             # Calculate center-to-center distances
             dx = abs(positions[i, 0] - positions[j, 0])
             dy = abs(positions[i, 1] - positions[j, 1])

--- a/macro_place/utils.py
+++ b/macro_place/utils.py
@@ -68,11 +68,12 @@ def validate_placement(
         if not torch.allclose(original_pos, new_pos, atol=1e-3):
             violations.append("Fixed macros have been moved")
 
-    # Check overlaps (matching SA.py IsFeasible logic)
+    # Check overlaps among hard macros only (soft macros naturally overlap)
     if check_overlaps:
         overlap_count = 0
-        for i in range(benchmark.num_macros):
-            for j in range(i + 1, benchmark.num_macros):
+        num_hard = getattr(benchmark, 'num_hard_macros', benchmark.num_macros)
+        for i in range(num_hard):
+            for j in range(i + 1, num_hard):
                 # Get bounding boxes
                 lx_i, ux_i = x_min[i].item(), x_max[i].item()
                 ly_i, uy_i = y_min[i].item(), y_max[i].item()

--- a/scripts/evaluate_with_orfs.py
+++ b/scripts/evaluate_with_orfs.py
@@ -285,6 +285,12 @@ def evaluate_benchmark(
     if placement_path is not None:
         placement = torch.load(placement_path, weights_only=True)
         print(f"✓ Loaded placement from {placement_path} (shape: {list(placement.shape)})")
+        # If only hard macros provided, pad with soft macro initial positions
+        if placement.shape[0] < benchmark.num_macros:
+            full = benchmark.macro_positions.clone()
+            full[:placement.shape[0]] = placement
+            placement = full
+            print(f"  Padded to full placement: {list(placement.shape)}")
     else:
         placement = benchmark.macro_positions
 


### PR DESCRIPTION
## Summary
Three harness fixes:

1. **`objective.py`**: `compute_overlap_metrics` now only checks hard-hard macro overlaps. Soft macros (standard cell clusters) naturally overlap and shouldn't be counted.

2. **`utils.py`**: Same fix in `validate_placement` — only validate hard macro overlaps.

3. **`evaluate_with_orfs.py`**: When `--placement` provides a hard-macro-only tensor `[num_hard, 2]`, automatically pad with soft macro initial positions to create the full `[num_macros, 2]` tensor expected by `compute_proxy_cost`.

## Why
After PR #14 added soft macros to the Benchmark tensor, the overlap counter started counting soft-soft overlaps (which are always present and expected). This caused valid placements to show thousands of "overlaps" and be marked INVALID.

## Test plan
- [x] `uv run evaluate greedy_row_placer.py -b ibm01` — no false overlap reports
- [x] `python scripts/evaluate_with_orfs.py --placement hard_only.pt` — pads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)