### PR TITLE
Prohibit soft overlaps

### DIFF
--- a/macro_place/evaluate.py
+++ b/macro_place/evaluate.py
@@ -128,7 +128,9 @@ def _load_placer(path: Path):
 # ── Single-benchmark evaluation ─────────────────────────────────────────────
 
 
-def evaluate_benchmark(placer, name: str, testcase_root: str, ng45_dir: str = None) -> dict:
+def evaluate_benchmark(
+    placer, name: str, testcase_root: str, ng45_dir: str = None
+) -> dict:
     """Run *placer* on a single benchmark and return a results dict."""
     if ng45_dir:
         netlist_file = f"{ng45_dir}/netlist.pb.txt"
@@ -190,12 +192,20 @@ def _print_summary_table(results):
                 else 0
             )
             vs_rep = (
-                ((r["replace_baseline"] - r["proxy_cost"]) / r["replace_baseline"] * 100)
+                (
+                    (r["replace_baseline"] - r["proxy_cost"])
+                    / r["replace_baseline"]
+                    * 100
+                )
                 if r["replace_baseline"]
                 else 0
             )
             sa_str = f"{r['sa_baseline']:>8.4f}" if r["sa_baseline"] else f"{'—':>8}"
-            rep_str = f"{r['replace_baseline']:>8.4f}" if r["replace_baseline"] else f"{'—':>8}"
+            rep_str = (
+                f"{r['replace_baseline']:>8.4f}"
+                if r["replace_baseline"]
+                else f"{'—':>8}"
+            )
             print(
                 f"{r['name']:>13}  {r['proxy_cost']:>8.4f}"
                 f"  {sa_str}  {rep_str}"
@@ -215,8 +225,16 @@ def _print_summary_table(results):
     if has_baselines:
         baselines_sa = [r for r in results if r["sa_baseline"] is not None]
         baselines_rep = [r for r in results if r["replace_baseline"] is not None]
-        avg_sa = sum(r["sa_baseline"] for r in baselines_sa) / len(baselines_sa) if baselines_sa else 0
-        avg_rep = sum(r["replace_baseline"] for r in baselines_rep) / len(baselines_rep) if baselines_rep else 0
+        avg_sa = (
+            sum(r["sa_baseline"] for r in baselines_sa) / len(baselines_sa)
+            if baselines_sa
+            else 0
+        )
+        avg_rep = (
+            sum(r["replace_baseline"] for r in baselines_rep) / len(baselines_rep)
+            if baselines_rep
+            else 0
+        )
         print("-" * 80)
         print(
             f"{'AVG':>13}  {avg_proxy:>8.4f}  {avg_sa:>8.4f}  {avg_rep:>8.4f}"
@@ -307,7 +325,9 @@ def main():
     results = []
     for name in benchmarks_to_run:
         print(f"  {name}...", end=" ", flush=True)
-        ng45_dir = NG45_BENCHMARKS.get(name) if args.ng45 or name in NG45_BENCHMARKS else None
+        ng45_dir = (
+            NG45_BENCHMARKS.get(name) if args.ng45 or name in NG45_BENCHMARKS else None
+        )
         result = evaluate_benchmark(placer, name, str(testcase_root), ng45_dir=ng45_dir)
         results.append(result)
 
@@ -326,7 +346,9 @@ def main():
             vis_dir = Path("vis")
             vis_dir.mkdir(exist_ok=True)
             save_path = str(vis_dir / f"{name}.png")
-            visualize_placement(result["placement"], result["benchmark"], save_path=save_path)
+            visualize_placement(
+                result["placement"], result["benchmark"], save_path=save_path
+            )
 
     if len(results) > 1:
         _print_summary_table(results)

--- a/macro_place/objective.py
+++ b/macro_place/objective.py
@@ -48,7 +48,7 @@ def compute_overlap_metrics(
 
     Returns:
         Dictionary with:
-            - overlap_count: Number of overlapping macro pairs
+            - overlap_count: Number of overlapping macro pairs (hard-hard, hard-soft, soft-soft)
             - total_overlap_area: Total area of all overlaps (μm²)
             - max_overlap_area: Largest single overlap area (μm²)
             - num_macros_with_overlaps: Number of macros involved in at least one overlap
@@ -75,10 +75,9 @@ def compute_overlap_metrics(
     max_overlap_area = 0.0
     macros_with_overlaps = set()
 
-    # Check hard macro pairs only for overlap (soft macros naturally overlap)
-    num_hard = getattr(benchmark, 'num_hard_macros', num_macros)
-    for i in range(num_hard):
-        for j in range(i + 1, num_hard):
+    # All macro pairs (hard and soft): overlaps are illegal for evaluation
+    for i in range(num_macros):
+        for j in range(i + 1, num_macros):
             # Calculate center-to-center distances
             dx = abs(positions[i, 0] - positions[j, 0])
             dy = abs(positions[i, 1] - positions[j, 1])
@@ -187,10 +186,10 @@ def _set_placement(plc: PlacementCost, placement: torch.Tensor, benchmark: Bench
     placement_np = placement.cpu().numpy()
 
     # Build macro_name -> [pin_indices] lookup (cached on plc)
-    if not hasattr(plc, '_macro_pin_map'):
+    if not hasattr(plc, "_macro_pin_map"):
         pin_map = {}
         for idx, mod in enumerate(plc.modules_w_pins):
-            if mod.get_type() == 'MACRO_PIN' and hasattr(mod, 'get_macro_name'):
+            if mod.get_type() == "MACRO_PIN" and hasattr(mod, "get_macro_name"):
                 name = mod.get_macro_name()
                 if name not in pin_map:
                     pin_map[name] = []

--- a/macro_place/utils.py
+++ b/macro_place/utils.py
@@ -19,12 +19,12 @@ def validate_placement(
     - No NaN/Inf values
     - Correct shape
     - Fixed macros at original positions
-    - No macro overlaps (optional, can be slow for large designs)
+    - No pairwise macro overlaps, including soft macros (optional; can be slow)
 
     Args:
         placement: [num_macros, 2] tensor of (x, y) positions
         benchmark: Benchmark object
-        check_overlaps: If True, check for macro-to-macro overlaps (default: True)
+        check_overlaps: If True, check pairwise overlaps among all macros (default: True)
 
     Returns:
         (is_valid, violations)
@@ -68,12 +68,12 @@ def validate_placement(
         if not torch.allclose(original_pos, new_pos, atol=1e-3):
             violations.append("Fixed macros have been moved")
 
-    # Check overlaps among hard macros only (soft macros naturally overlap)
+    # Check overlaps among all macros (hard and soft)
     if check_overlaps:
         overlap_count = 0
-        num_hard = getattr(benchmark, 'num_hard_macros', benchmark.num_macros)
-        for i in range(num_hard):
-            for j in range(i + 1, num_hard):
+        n = benchmark.num_macros
+        for i in range(n):
+            for j in range(i + 1, n):
                 # Get bounding boxes
                 lx_i, ux_i = x_min[i].item(), x_max[i].item()
                 ly_i, uy_i = y_min[i].item(), y_max[i].item()

--- a/submissions/examples/greedy_row_placer.py
+++ b/submissions/examples/greedy_row_placer.py
@@ -2,9 +2,9 @@
 Greedy Row Placer - Demo Submission
 
 A simple but legal placer that:
-1. Sorts macros by height (tallest first)
+1. Sorts movable macros by height (tallest first)
 2. Places them left-to-right in rows (like shelf packing)
-3. Guarantees zero overlaps and canvas boundary compliance
+3. Guarantees zero overlaps among all macros (hard and soft) and canvas compliance
 
 This produces valid, scoreable placements but makes no attempt to
 optimize wirelength, density, or congestion. Use it as a starting
@@ -25,14 +25,13 @@ class GreedyRowPlacer:
     """
     Greedy row-based (shelf packing) placement.
 
-    Places macros in rows from bottom to top, left to right,
-    sorted by descending height. Guarantees zero overlaps.
+    Places every movable macro (hard and soft) in rows from bottom to top,
+    left to right, sorted by descending height. Guarantees zero pairwise overlaps.
     """
 
     def place(self, benchmark: Benchmark) -> torch.Tensor:
         placement = benchmark.macro_positions.clone()
-        # Only place hard macros; soft macros stay at initial positions
-        movable = benchmark.get_movable_mask() & benchmark.get_hard_macro_mask()
+        movable = benchmark.get_movable_mask()
         movable_indices = torch.where(movable)[0].tolist()
 
         sizes = benchmark.macro_sizes


### PR DESCRIPTION
There was an issue with the original evaluation script that allowed soft macros to overlap. We've fixed the example greedy row placer and the eval script to prevent this.