### PR TITLE
Add air-gapped Docker evaluator for submission verification

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Docker build context exclusions for eval_docker/
+.git/
+submissions_eval/
+assets/
+benchmarks/processed/
+eval_docker/results/
+*.gif
+*.png
+os_debug.txt

--- a/eval_docker/Dockerfile
+++ b/eval_docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime
+
+# Avoid interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system deps
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /challenge
+
+# Copy the challenge evaluation infrastructure
+COPY macro_place/ /challenge/macro_place/
+COPY pyproject.toml /challenge/pyproject.toml
+COPY requirements.txt /challenge/requirements.txt
+
+# Copy benchmarks (read-only at runtime, but needed in image)
+COPY external/MacroPlacement/Testcases/ICCAD04/ /challenge/external/MacroPlacement/Testcases/ICCAD04/
+
+# Install challenge package and base deps
+RUN pip install --no-cache-dir -e . && \
+    pip install --no-cache-dir scipy tqdm
+
+# Pre-install common extra deps that submissions may need
+# (cheaper to bake in than install at runtime)
+RUN pip install --no-cache-dir cvxpy dccp numba
+
+# Entrypoint: run the evaluator on a mounted placer file
+# Usage: docker run ... -v /path/to/placer.py:/submission/placer.py evaluate /submission/placer.py --all
+ENTRYPOINT ["python", "-m", "macro_place.evaluate"]

--- a/eval_docker/Dockerfile
+++ b/eval_docker/Dockerfile
@@ -19,6 +19,12 @@ COPY requirements.txt /challenge/requirements.txt
 # Copy benchmarks (read-only at runtime, but needed in image)
 COPY external/MacroPlacement/Testcases/ICCAD04/ /challenge/external/MacroPlacement/Testcases/ICCAD04/
 
+# Copy PlacementCost evaluator (plc_client_os from TILOS submodule)
+COPY external/MacroPlacement/CodeElements/Plc_client/ /challenge/external/MacroPlacement/CodeElements/Plc_client/
+
+# Copy example submissions (for smoke testing)
+COPY submissions/examples/ /challenge/submissions/examples/
+
 # Install challenge package and base deps
 RUN pip install --no-cache-dir -e . && \
     pip install --no-cache-dir scipy tqdm

--- a/eval_docker/run_eval.sh
+++ b/eval_docker/run_eval.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Air-gapped Docker evaluation of a macro placement submission.
+#
+# Usage:
+#   ./eval_docker/run_eval.sh <team_name> <placer_path> [extra_mount...]
+#
+# Examples:
+#   ./eval_docker/run_eval.sh convex_opt submissions_eval/convex_opt/submissions/dccp_placer.py
+#   ./eval_docker/run_eval.sh mtk submissions_eval/mtk_dreamplace_pp/submissions/placer.py \
+#       submissions_eval/mtk_dreamplace_pp/submissions/dreamplace
+#
+# The container runs with:
+#   --network none    (air-gapped, no internet)
+#   --gpus all        (GPU access for DREAMPlace etc.)
+#   --memory 64g      (prevent OOM from killing host)
+#   --cpus 16         (resource limit)
+#   timeout 7200      (2 hour wall-clock limit)
+
+set -euo pipefail
+
+TEAM="${1:?Usage: $0 <team_name> <placer_path> [extra_mount...]}"
+PLACER_PATH="${2:?Usage: $0 <team_name> <placer_path> [extra_mount...]}"
+shift 2
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+IMAGE_NAME="macro-place-eval"
+RESULTS_DIR="$REPO_ROOT/eval_docker/results"
+
+mkdir -p "$RESULTS_DIR"
+
+# Build image if needed
+if ! docker image inspect "$IMAGE_NAME" &>/dev/null; then
+    echo "=== Building evaluation Docker image ==="
+    docker build -t "$IMAGE_NAME" -f "$SCRIPT_DIR/Dockerfile" "$REPO_ROOT"
+fi
+
+# Resolve placer path
+ABS_PLACER="$(cd "$REPO_ROOT" && realpath "$PLACER_PATH")"
+PLACER_DIR="$(dirname "$ABS_PLACER")"
+PLACER_FILE="$(basename "$ABS_PLACER")"
+
+# Build mount arguments
+# Always mount the placer's directory
+MOUNT_ARGS="-v $PLACER_DIR:/submission:ro"
+
+# Mount any extra directories (e.g., bundled DREAMPlace package)
+for extra in "$@"; do
+    ABS_EXTRA="$(cd "$REPO_ROOT" && realpath "$extra")"
+    BASE_EXTRA="$(basename "$ABS_EXTRA")"
+    MOUNT_ARGS="$MOUNT_ARGS -v $ABS_EXTRA:/submission/$BASE_EXTRA:ro"
+done
+
+echo "=== Evaluating: $TEAM ==="
+echo "    Placer: $PLACER_PATH"
+echo "    Image:  $IMAGE_NAME"
+echo "    Network: NONE (air-gapped)"
+echo ""
+
+# Run with air-gapping and resource limits
+timeout 7200 docker run --rm \
+    --network none \
+    --gpus all \
+    --memory 64g \
+    --cpus 16 \
+    $MOUNT_ARGS \
+    "$IMAGE_NAME" \
+    "/submission/$PLACER_FILE" --all \
+    2>&1 | tee "$RESULTS_DIR/${TEAM}.log"
+
+echo ""
+echo "=== Results saved to: $RESULTS_DIR/${TEAM}.log ==="


### PR DESCRIPTION
## Summary
- Adds `eval_docker/Dockerfile` — PyTorch+CUDA image with challenge evaluation infra + common deps (cvxpy, dccp, numba, scipy)
- Adds `eval_docker/run_eval.sh` — wrapper that runs submissions with `--network none` (air-gapped), `--gpus all`, 64GB RAM limit, 16 CPU limit, 2hr timeout
- Adds `.dockerignore` to keep build context lean

## Usage
```bash
# Build image (auto-built on first run)
docker build -t macro-place-eval -f eval_docker/Dockerfile .

# Evaluate a submission (air-gapped)
./eval_docker/run_eval.sh <team_name> <placer_path> [extra_mount_dirs...]

# Example: simple placer
./eval_docker/run_eval.sh convex_opt submissions_eval/convex_opt/submissions/dccp_placer.py

# Example: placer with bundled deps (DREAMPlace)
./eval_docker/run_eval.sh mtk submissions_eval/mtk_dreamplace_pp/submissions/placer.py \
    submissions_eval/mtk_dreamplace_pp/submissions/dreamplace
```

Results are saved to `eval_docker/results/<team_name>.log`.

## Test plan
- [ ] Build Docker image successfully
- [ ] Run evaluation of a known-good placer (greedy_row_placer) and verify scores match
- [ ] Verify `--network none` actually blocks network access
- [ ] Run one GPU submission (MTK DREAMPlace++) end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)