### PR TITLE
Add 3 new leaderboard entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,21 +224,24 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 
 | Rank | Team | Avg Proxy Cost | Best | Worst | Overlaps | Runtime | Verified |
 |------|------|---------------|------|-------|----------|---------|----------|
-| 1 | "MTK" (DreamPlace++) | **1.3998** | — | — | 0 | 25s/bench | |
-| 2 | "Varun's Parallel Worlds" (GRPlace) | **1.4044** | — | — | 0 | 125s/bench | |
-| 3 | "UT Austin" - AS (DREAMPlace Analytical) | **1.4076** | — | — | 0 | 17s/bench | |
-| 4 | "ByteDancer" (Incremental CD) | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: |
-| 5 | "BakaBobo" (Spread+Refine) | **1.4403** | — | — | 0 | 212s/bench | |
-| ~~6~~ | ~~"Convex Optimization" (UWaterloo Student)~~ | ~~1.4556~~ | — | — | **846** | — | :x: DQ |
-| 6 | "another Waterloo kid" (Batched Nesterov GP) | **1.4568** | — | — | 0 | 118s/bench | |
+| 1 | "Mike Gao" (autoresearch) | **1.3255** | — | — | 0 | 16min/bench | |
+| 2 | "Electric Beatel" (ePlace-Lite) | **1.3874** | — | — | 0 | 283s/bench (GPU) | |
+| 3 | "MTK" (DreamPlace++) | **1.3998** | — | — | 0 | 25s/bench | |
+| 4 | "Varun's Parallel Worlds" (GRPlace) | **1.4044** | — | — | 0 | 125s/bench | |
+| 5 | "UT Austin" - AS (DREAMPlace Analytical) | **1.4076** | — | — | 0 | 17s/bench | |
+| 6 | "ByteDancer" (Incremental CD) | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: |
+| 7 | "BakaBobo" (Spread+Refine) | **1.4403** | — | — | 0 | 212s/bench | |
+| ~~—~~ | ~~"Convex Optimization" (UWaterloo Student)~~ | ~~1.4556~~ | — | — | **846** | — | :x: DQ |
+| 8 | "another Waterloo kid" (Batched Nesterov GP) | **1.4568** | — | — | 0 | 118s/bench | |
 | — | RePlAce (baseline) | **1.4578** | 0.9976 | 1.8370 | 0 | — | :white_check_mark: |
-| 7 | "UTAUSTIN-CT" (PLC-Exact Congestion-Aware SA) | **1.5062** | — | — | 0 | 35s/bench | |
-| 8 | "oracleX" (Oracle) | **1.5130** | — | — | 0 | 3min/bench | |
-| 9 | "CA" (congestion_aware) | **1.5238** | — | — | 0 | 13s/bench | |
-| 10 | Will Seed (Partcl) | **1.5338** | 1.1625 | 1.7965 | 0 | 35s total | :white_check_mark: |
-| 11 | "Cezar" (CRISP) | **1.5781** | 1.1896 | 1.8520 | 0 | 4min/bench | :white_check_mark: |
-| 12 | "UT Austin" - RH (DREAMPlace) | **1.6037** | — | — | 0 | 4.5s/bench | |
-| 13 | "UT Austin" - CT (PROXYCost) | **1.8706** | — | — | 0 | 187s/bench | |
+| 9 | "UTAUSTIN-CT" (PLC-Exact Congestion-Aware SA) | **1.5062** | — | — | 0 | 35s/bench | |
+| 10 | "oracleX" (Oracle) | **1.5130** | — | — | 0 | 3min/bench | |
+| 11 | "CA" (congestion_aware) | **1.5238** | — | — | 0 | 13s/bench | |
+| 12 | "#5 ubc cpen student" (Gene Pool Shuffle) | **1.5290** | — | — | 0 | 281s/bench | |
+| 13 | Will Seed (Partcl) | **1.5338** | 1.1625 | 1.7965 | 0 | 35s total | :white_check_mark: |
+| 14 | "Cezar" (CRISP) | **1.5781** | 1.1896 | 1.8520 | 0 | 4min/bench | :white_check_mark: |
+| 15 | "UT Austin" - RH (DREAMPlace) | **1.6037** | — | — | 0 | 4.5s/bench | |
+| 16 | "UT Austin" - CT (PROXYCost) | **1.8706** | — | — | 0 | 187s/bench | |
 | — | SA (baseline) | 2.1251 | 1.3166 | 3.6726 | 0 | — | :white_check_mark: |
 | — | Greedy Row (demo) | 2.2109 | 1.6728 | 2.7696 | 0 | 0.3s total | :white_check_mark: |
 | — | "Binghamton" (feng shui) | pending | — | — | — | — | |


### PR DESCRIPTION
## Summary
- Add **Mike Gao** (autoresearch) at #1 with **1.3255** avg proxy cost
- Add **Electric Beatel** (ePlace-Lite) at #2 with **1.3874** avg proxy cost
- Add **#5 ubc cpen student** (Gene Pool Shuffle) at #12 with **1.5290** avg proxy cost
- Renumber all existing ranks accordingly
- Preserves verification status for ByteDancer, Cezar, and Convex Optimization DQ from main

🤖 Generated with [Claude Code](https://claude.com/claude-code)