### PR TITLE
Verify MTK DreamPlace++ — improved to 1.3622 (rank 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 | Rank | Team | Avg Proxy Cost | Best | Worst | Overlaps | Runtime | Verified |
 |------|------|---------------|------|-------|----------|---------|----------|
 | 1 | "Mike Gao" (autoresearch) | **1.3255** | — | — | 0 | 16min/bench | |
-| 2 | "Electric Beatel" (ePlace-Lite) | **1.3913** | 0.9773 | 1.7253 | 0 | 155s/bench (GPU) | :white_check_mark: |
-| 3 | "MTK" (DreamPlace++) | **1.3998** | — | — | 0 | 25s/bench | |
+| 2 | "MTK" (DreamPlace++) | **1.3622** | 1.0040 | 1.6710 | 0 | 112s/bench (GPU) | :white_check_mark: |
+| 3 | "Electric Beatel" (ePlace-Lite) | **1.3913** | 0.9773 | 1.7253 | 0 | 155s/bench (GPU) | :white_check_mark: |
 | 4 | "Varun's Parallel Worlds" (GRPlace) | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: |
 | 5 | "UT Austin" - AS (DREAMPlace Analytical) | **1.4076** | — | — | 0 | 17s/bench | |
 | 6 | "ByteDancer" (Incremental CD) | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: |

--- a/README.md
+++ b/README.md
@@ -222,32 +222,30 @@ Classical methods (SA, RePlAce) have been refined for decades but still have roo
 
 Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (lower is better). Zero overlaps required on all benchmarks. Scores are unverified until confirmed by judges.
 
-| Rank | Team | Avg Proxy Cost | Best | Worst | Overlaps | Runtime | Verified |
-|------|------|---------------|------|-------|----------|---------|----------|
-| 1 | "Mike Gao" (autoresearch) | **1.3255** | — | — | 0 | 16min/bench | |
-| 2 | "MTK" (DreamPlace++) | **1.3622**\* | 1.0040 | 1.6710 | 0 | 112s/bench (GPU) | :white_check_mark: |
-| 3 | "Electric Beatel" (ePlace-Lite) | **1.3913** | 0.9773 | 1.7253 | 0 | 155s/bench (GPU) | :white_check_mark: |
-| 4 | "Varun's Parallel Worlds" (GRPlace) | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: |
-| 5 | "UT Austin" - AS (DREAMPlace Analytical) | **1.4076** | — | — | 0 | 17s/bench | |
-| 6 | "ByteDancer" (Incremental CD) | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: |
-| 7 | "BakaBobo" (Spread+Refine) | **1.4403** | — | — | 0 | 212s/bench | |
-| ~~—~~ | ~~"Convex Optimization" (UWaterloo Student)~~ | ~~1.4556~~ | — | — | **846** | — | :x: DQ |
-| 8 | "another Waterloo kid" (Batched Nesterov GP) | **1.4568** | — | — | 0 | 118s/bench | |
-| — | RePlAce (baseline) | **1.4578** | 0.9976 | 1.8370 | 0 | — | :white_check_mark: |
-| 9 | "UTAUSTIN-CT" (PLC-Exact Congestion-Aware SA) | **1.5062** | — | — | 0 | 35s/bench | |
-| 10 | "oracleX" (Oracle) | **1.5130** | — | — | 0 | 3min/bench | |
-| 11 | "CA" (congestion_aware) | **1.5238** | — | — | 0 | 13s/bench | |
-| 12 | "#5 ubc cpen student" (Gene Pool Shuffle) | **1.5337** | 1.1411 | 1.8084 | 0 | 13s/bench | :white_check_mark: |
-| 13 | Will Seed (Partcl) | **1.5338** | 1.1625 | 1.7965 | 0 | 35s total | :white_check_mark: |
-| 14 | "Cezar" (CRISP) | **1.5781** | 1.1896 | 1.8520 | 0 | 4min/bench | :white_check_mark: |
-| 15 | "UT Austin" - RH (DREAMPlace) | **1.6037** | — | — | 0 | 4.5s/bench | |
-| 16 | "UT Austin" - CT (PROXYCost) | **1.8706** | — | — | 0 | 187s/bench | |
-| — | SA (baseline) | 2.1251 | 1.3166 | 3.6726 | 0 | — | :white_check_mark: |
-| — | Greedy Row (demo) | 2.2109 | 1.6728 | 2.7696 | 0 | 0.3s total | :white_check_mark: |
-| — | "Binghamton" (feng shui) | pending | — | — | — | — | |
-| — | "MacroBio" (Two-Opt Swap) | pending | — | — | — | — | |
-
-\*Verified score is better than self-reported (1.3998). Likely due to faster GPU on evaluation hardware.
+| Rank | Team | Avg Proxy Cost | Best | Worst | Overlaps | Runtime | Verified | Notes |
+|------|------|---------------|------|-------|----------|---------|----------|-------|
+| 1 | "Mike Gao" (autoresearch) | **1.3255** | — | — | 0 | 16min/bench | | |
+| 2 | "MTK" (DreamPlace++) | **1.3622** | 1.0040 | 1.6710 | 0 | 112s/bench (GPU) | :white_check_mark: | Verified better than self-reported 1.3998; faster GPU on eval hardware |
+| 3 | "Electric Beatel" (ePlace-Lite) | **1.3913** | 0.9773 | 1.7253 | 0 | 155s/bench (GPU) | :white_check_mark: | |
+| 4 | "Varun's Parallel Worlds" (GRPlace) | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: | |
+| 5 | "UT Austin" - AS (DREAMPlace Analytical) | **1.4076** | — | — | 0 | 17s/bench | | |
+| 6 | "ByteDancer" (Incremental CD) | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: | |
+| 7 | "BakaBobo" (Spread+Refine) | **1.4403** | — | — | 0 | 212s/bench | | |
+| ~~—~~ | ~~"Convex Optimization" (UWaterloo Student)~~ | ~~1.4556~~ | — | — | **846** | — | :x: DQ | Verified 2.1224 avg, 846 overlaps |
+| 8 | "another Waterloo kid" (Batched Nesterov GP) | **1.4568** | — | — | 0 | 118s/bench | | |
+| — | RePlAce (baseline) | **1.4578** | 0.9976 | 1.8370 | 0 | — | :white_check_mark: | |
+| 9 | "UTAUSTIN-CT" (PLC-Exact Congestion-Aware SA) | **1.5062** | — | — | 0 | 35s/bench | | |
+| 10 | "oracleX" (Oracle) | **1.5130** | — | — | 0 | 3min/bench | | |
+| 11 | "CA" (congestion_aware) | **1.5238** | — | — | 0 | 13s/bench | | |
+| 12 | "#5 ubc cpen student" (Gene Pool Shuffle) | **1.5337** | 1.1411 | 1.8084 | 0 | 13s/bench | :white_check_mark: | |
+| 13 | Will Seed (Partcl) | **1.5338** | 1.1625 | 1.7965 | 0 | 35s total | :white_check_mark: | |
+| 14 | "Cezar" (CRISP) | **1.5781** | 1.1896 | 1.8520 | 0 | 4min/bench | :white_check_mark: | |
+| 15 | "UT Austin" - RH (DREAMPlace) | **1.6037** | — | — | 0 | 4.5s/bench | | |
+| 16 | "UT Austin" - CT (PROXYCost) | **1.8706** | — | — | 0 | 187s/bench | | |
+| — | SA (baseline) | 2.1251 | 1.3166 | 3.6726 | 0 | — | :white_check_mark: | |
+| — | Greedy Row (demo) | 2.2109 | 1.6728 | 2.7696 | 0 | 0.3s total | :white_check_mark: | |
+| — | "Binghamton" (feng shui) | pending | — | — | — | — | | |
+| — | "MacroBio" (Two-Opt Swap) | pending | — | — | — | — | | |
 
 *Submit your results via the [Submission Link](https://forms.gle/YDRtYV5Vq68SZgKW9)!*
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 | Rank | Team | Avg Proxy Cost | Best | Worst | Overlaps | Runtime | Verified |
 |------|------|---------------|------|-------|----------|---------|----------|
 | 1 | "Mike Gao" (autoresearch) | **1.3255** | — | — | 0 | 16min/bench | |
-| 2 | "MTK" (DreamPlace++) | **1.3622** | 1.0040 | 1.6710 | 0 | 112s/bench (GPU) | :white_check_mark: |
+| 2 | "MTK" (DreamPlace++) | **1.3622**\* | 1.0040 | 1.6710 | 0 | 112s/bench (GPU) | :white_check_mark: |
 | 3 | "Electric Beatel" (ePlace-Lite) | **1.3913** | 0.9773 | 1.7253 | 0 | 155s/bench (GPU) | :white_check_mark: |
 | 4 | "Varun's Parallel Worlds" (GRPlace) | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: |
 | 5 | "UT Austin" - AS (DREAMPlace Analytical) | **1.4076** | — | — | 0 | 17s/bench | |
@@ -246,6 +246,8 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 | — | Greedy Row (demo) | 2.2109 | 1.6728 | 2.7696 | 0 | 0.3s total | :white_check_mark: |
 | — | "Binghamton" (feng shui) | pending | — | — | — | — | |
 | — | "MacroBio" (Two-Opt Swap) | pending | — | — | — | — | |
+
+\*Verified score is better than self-reported (1.3998). Likely due to faster GPU on evaluation hardware.
 
 *Submit your results via the [Submission Link](https://forms.gle/YDRtYV5Vq68SZgKW9)!*
 


### PR DESCRIPTION
## Summary
- **MTK DreamPlace++**: VERIFIED **1.3622** avg (claimed 1.3998), 0 overlaps across all 17 IBM benchmarks

Score is **better** than claimed — our RTX 6000 Ada GPUs likely allow the optimizer more iterations within the time budget.

Built DREAMPlace from source with CUDA in Docker (`Dockerfile.dreamplace`), compiled for sm_80 (forward-compatible with Ada Lovelace sm_89). Evaluated air-gapped (`--network none`, 0B NET I/O).

Moves MTK from rank 3 to **rank 2** (above Electric Beatel at 1.3913).

### Per-benchmark results
| Bench | Proxy | vs SA | vs RePlAce |
|---|---|---|---|
| ibm01 | 1.0442 | +20.7% | -4.7% |
| ibm09 | 1.0040 | +27.6% | +10.3% |
| ibm17 | 1.6710 | +54.5% | -1.6% |
| **AVG** | **1.3622** | **+35.9%** | **+6.6%** |

## Test plan
- [x] Built DREAMPlace from source in Docker with CUDA
- [x] Ran MTK on all 17 IBM benchmarks
- [x] Verified 0B network I/O (air-gapped)
- [x] All 17 benchmarks valid with 0 overlaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)