### PR TITLE
Scale proxy coordinates to ORFS core area for Tier 2 evaluation

### DIFF
--- a/scripts/generate_macro_placement_tcl.py
+++ b/scripts/generate_macro_placement_tcl.py
@@ -138,16 +138,34 @@ def write_orfs_macro_placement(placement, benchmark, plc, output_file, core_area
     per genblk). Instead of guessing, we match at runtime by grouping ODB
     instances by their sram block prefix and assigning linear indices.
 
+    When core_area is provided, proxy canvas coordinates are **scaled** to fill
+    the ORFS core area (the proxy canvas and ORFS die have different dimensions).
+
     Args:
         placement: [num_macros, 2] tensor of (x, y) positions in microns
         benchmark: Benchmark object
         plc: PlacementCost object
         output_file: Output TCL file path
-        core_area: Optional tuple (x_min, y_min, x_max, y_max) to clamp positions
+        core_area: Optional tuple (x_min, y_min, x_max, y_max) to scale+clamp positions
     """
     from collections import defaultdict
 
     placement_np = placement.cpu().numpy()
+
+    # Compute scale factors from proxy canvas to ORFS core
+    canvas_w = float(benchmark.canvas_width)
+    canvas_h = float(benchmark.canvas_height)
+    if core_area is not None:
+        core_x_min, core_y_min, core_x_max, core_y_max = core_area
+        core_w = core_x_max - core_x_min
+        core_h = core_y_max - core_y_min
+        scale_x = core_w / canvas_w
+        scale_y = core_h / canvas_h
+        offset_x = core_x_min
+        offset_y = core_y_min
+        print(f"  Proxy canvas: {canvas_w:.1f} x {canvas_h:.1f}")
+        print(f"  ORFS core:    {core_w:.1f} x {core_h:.1f} (offset {offset_x:.1f}, {offset_y:.1f})")
+        print(f"  Scale factors: {scale_x:.4f} x {scale_y:.4f}")
 
     # Build placement data keyed by (group_prefix, flat_macro_index)
     group_data = defaultdict(dict)  # group_prefix -> {K: (x, y, orient, plc_name)}
@@ -163,8 +181,12 @@ def write_orfs_macro_placement(placement, benchmark, plc, output_file, core_area
         y_ll = y - h / 2
 
         if core_area is not None:
+            # Scale proxy coordinates to ORFS core area
+            x_ll = x_ll * scale_x + offset_x
+            y_ll = y_ll * scale_y + offset_y
+            # Clamp to core bounds with margin for PDN channels
+            # (macro sizes are physical — not scaled)
             margin = 2.0
-            core_x_min, core_y_min, core_x_max, core_y_max = core_area
             x_ll = max(core_x_min + margin, min(x_ll, core_x_max - w - margin))
             y_ll = max(core_y_min + margin, min(y_ll, core_y_max - h - margin))
 


### PR DESCRIPTION
## Summary
Fixes #47 — proxy canvas coordinates now scale to fill the ORFS core area.

The proxy canvas and ORFS die have different dimensions:
- **ariane133**: proxy 1433x1433 → ORFS core 2052x2100
- Scale factors: ~1.43x horizontal, ~1.47x vertical

Previously, proxy coordinates were passed through with only clamping, so all macros ended up in the lower-left ~70% of the die. The TILOS human placement (`place_srams.tcl`) uses `fp_urx`/`fp_ury` to spread macros across the full core.

Now: `x_orfs = x_proxy * (core_w / canvas_w) + core_x_min`

Macro sizes are physical (not scaled) — only positions are mapped. Clamped with 2um margin for PDN channels.

## Test plan
- [ ] Run ariane133_ng45 through ORFS with scaled coordinates
- [ ] Verify macros spread across full die (not clustered in lower-left)
- [ ] Check no PDN channel failures (PDN-0179) or overlap errors (MPL-0041)

🤖 Generated with [Claude Code](https://claude.com/claude-code)