### PR TITLE
Verify Cezar (ReFine): score is 1.2224, not self-reported 1.0666

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 
 | Rank | Team | Avg Proxy Cost | Best | Worst | Overlaps | Runtime | Verified | Notes |
 |------|------|---------------|------|-------|----------|---------|----------|-------|
-| 1 | "Cezar" (ReFine) | **1.0666** | — | — | 0 | 5min/bench | | Updated 4/21; previous CRISP verified at 1.5781 |
+| 1 | "Cezar" (ReFine) | **1.2224** | 0.8843 | 1.5115 | 0 | 5min/bench | :white_check_mark: | Verified 1.2224 vs self-reported 1.0666; beats RePlAce by 16.2%, SA by 42.5%; previous CRISP verified at 1.5781 |
 | 2 | "MTK" (DreamPlace++) | **1.2818** | 0.9073 | 1.6529 | 0 | 37s/bench (GPU) | :white_check_mark: | Verified better than self-reported 1.317; beats RePlAce on all 17 benchmarks |
 | 3 | "RoRa" (RipPlace) | **1.3241** | — | — | 0 | 694s/bench | | |
 | 4 | "Mike Gao" (autoresearch) | **1.3255** | — | — | 0 | 16min/bench | | |


### PR DESCRIPTION
## Summary
- Re-ran Cezar's ReFine submission on a separate machine: average proxy cost is **1.2224** across all 17 IBM benchmarks, zero overlaps.
- Self-reported score was 1.0666 (~14.6% better than what we measured). Likely a different environment (GPU or alternate code path).
- Cezar stays at rank 1 — 1.2224 still beats MTK's verified 1.2818.
- Verified result improves on RePlAce by 16.2% and SA by 42.5% on average.

### Per-benchmark results
| Benchmark | Proxy | SA | RePlAce | vs SA | vs RePlAce |
|-----------|-------|-----|---------|-------|-----------|
| ibm01 | 0.9115 | 1.3166 | 0.9976 | +30.8% | +8.6% |
| ibm02 | 1.2921 | 1.9072 | 1.8370 | +32.2% | +29.7% |
| ibm03 | 1.1892 | 1.7401 | 1.3222 | +31.7% | +10.1% |
| ibm04 | 1.1446 | 1.5037 | 1.3024 | +23.9% | +12.1% |
| ibm06 | 1.4101 | 2.5057 | 1.6187 | +43.7% | +12.9% |
| ibm07 | 1.1982 | 2.0229 | 1.4633 | +40.8% | +18.1% |
| ibm08 | 1.3217 | 1.9239 | 1.4285 | +31.3% | +7.5% |
| ibm09 | 0.8843 | 1.3875 | 1.1194 | +36.3% | +21.0% |
| ibm10 | 1.1647 | 2.1108 | 1.5009 | +44.8% | +22.4% |
| ibm11 | 0.9446 | 1.7111 | 1.1774 | +44.8% | +19.8% |
| ibm12 | 1.4100 | 2.8261 | 1.7261 | +50.1% | +18.3% |
| ibm13 | 1.0616 | 1.9141 | 1.3355 | +44.5% | +20.5% |
| ibm14 | 1.3147 | 2.2750 | 1.5436 | +42.2% | +14.8% |
| ibm15 | 1.3761 | 2.3000 | 1.5159 | +40.2% | +9.2% |
| ibm16 | 1.2251 | 2.2337 | 1.4780 | +45.2% | +17.1% |
| ibm17 | 1.4206 | 3.6726 | 1.6446 | +61.3% | +13.6% |
| ibm18 | 1.5115 | 2.7755 | 1.7722 | +45.5% | +14.7% |
| **AVG** | **1.2224** | **2.1251** | **1.4578** | **+42.5%** | **+16.2%** |

## Test plan
- [x] Eval re-ran on separate machine, zero overlaps on all 17 benchmarks
- [ ] Visual check of rendered leaderboard table on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)