### PR TITLE
Fix Tier 2 ORFS evaluation for all NG45 designs

### DIFF
--- a/scripts/evaluate_with_orfs.py
+++ b/scripts/evaluate_with_orfs.py
@@ -306,6 +306,48 @@ def evaluate_benchmark(
     else:
         orfs_config_dir = Path(f"external/MacroPlacement/Flows/ASAP7/{source_name}/scripts/OpenROAD/{source_name}")
 
+    # Generate ORFS config for nvdla if it doesn't exist (no upstream collateral)
+    if not orfs_config_dir.exists() and source_name == "nvdla":
+        orfs_config_dir.mkdir(parents=True, exist_ok=True)
+        enable_dir = Path("external/MacroPlacement/Enablements/NanGate45")
+        netlist_dir = Path(f"external/MacroPlacement/Flows/NanGate45/nvdla/netlist")
+
+        # Copy Genus netlist and fakeram files
+        shutil.copy(netlist_dir / "NV_NVDLA_partition_c.v", orfs_config_dir)
+        shutil.copy(enable_dir / "lef" / "fakeram45_256x64.lef", orfs_config_dir)
+        shutil.copy(enable_dir / "lib" / "fakeram45_256x64.lib", orfs_config_dir)
+
+        # Write config.mk
+        (orfs_config_dir / "config.mk").write_text("""\
+export DESIGN_NICKNAME = nvdla
+export DESIGN_NAME = NV_nvdla
+export PLATFORM    = nangate45
+
+export VERILOG_FILES = ./designs/$(PLATFORM)/$(DESIGN_NICKNAME)/NV_NVDLA_partition_c.v
+
+export SDC_FILE      = ./designs/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
+export ABC_CLOCK_PERIOD_IN_PS = 2000
+
+export ADDITIONAL_LEFS = ./designs/$(PLATFORM)/$(DESIGN_NICKNAME)/fakeram45_256x64.lef
+export ADDITIONAL_LIBS = ./designs/$(PLATFORM)/$(DESIGN_NICKNAME)/fakeram45_256x64.lib
+
+export DIE_AREA    = 0.0 0.0 3200.00 3200.00
+export CORE_AREA   = 10.07 9.94 3189.93 3190.06
+export PLACE_PINS_ARGS = -exclude left:0-400 -exclude left:2800-3200 \\
+                         -exclude right:0-400 -exclude right:2800-3200 \\
+                         -exclude top:0-400 -exclude top:2800-3200 \\
+                         -exclude bottom:0-400 -exclude bottom:2800-3200
+
+export PLACE_DENSITY_LB_ADDON ?= 0.10
+""")
+        # Write constraint.sdc (4ns clock matching other NG45 benchmarks)
+        (orfs_config_dir / "constraint.sdc").write_text("""\
+create_clock [get_ports nvdla_core_clk]  -name core_clock  -period 4
+set_input_delay -clock core_clock 0 [all_inputs]
+set_output_delay -clock core_clock 0 [all_outputs]
+""")
+        print(f"  ✓ Generated ORFS config for nvdla (128 macros, fakeram45_256x64)")
+
     # Fallback: check ORFS built-in designs (maps source_name to ORFS design name)
     orfs_builtin_map = {
         'bp_quad': 'black_parrot',
@@ -358,6 +400,29 @@ def evaluate_benchmark(
         config_mk = design_dir / "config.mk"
         if config_mk.exists():
             config_content = config_mk.read_text()
+
+            # Use pre-mapped Genus gate netlist when available (bypasses Yosys).
+            # This fixes ariane133 where PRESERVE_CELLS causes Yosys to drop
+            # 89 of 133 SRAMs (see issue #50).
+            genus_netlist_dir = Path(
+                f"external/MacroPlacement/Flows/NanGate45/{source_name}/netlist"
+            )
+            if genus_netlist_dir.exists():
+                for candidate in sorted(genus_netlist_dir.glob("*.v")):
+                    with open(candidate) as fv:
+                        n_sram = sum(1 for line in fv if "fakeram45_" in line)
+                    if n_sram > 0:
+                        abs_path = candidate.resolve()
+                        config_content += (
+                            f"\n# Override: use Genus-mapped gate netlist ({n_sram} SRAMs)\n"
+                            f"export SYNTH_NETLIST_FILES = {abs_path}\n"
+                        )
+                        # Remove stale Yosys cache so ORFS uses the Genus netlist
+                        stale_yosys = orfs_root / "flow" / "results" / tech / source_name / "base" / "1_2_yosys.v"
+                        if stale_yosys.is_file():
+                            stale_yosys.unlink()
+                        print(f"  ✓ Using Genus gate netlist: {candidate.name} ({n_sram} SRAMs)")
+                        break
 
             if source_name == "mempool_tile":
                 # 1. Disable hierarchical flow

--- a/scripts/generate_macro_placement_tcl.py
+++ b/scripts/generate_macro_placement_tcl.py
@@ -125,6 +125,31 @@ def _plc_extract_group_and_index(plc_name):
     return prefix, macro_idx
 
 
+def _plc_to_odb_name(plc_name):
+    """Convert a .plc hierarchical name to the flat ODB instance name.
+
+    Verilog hierarchy flattens to ODB with:
+      '/' -> '.'
+      '[N].' -> '_N__'  (mid-hierarchy generate index)
+      '[N]' at end -> '_N_' (trailing generate index)
+      '.' within a level stays as '.' in ODB
+
+    Examples:
+      i_tile/gen_banks[3].mem_bank/genblk1.sram_instance
+        -> i_tile.gen_banks_3__mem_bank.genblk1.sram_instance
+
+      u_NV_NVDLA_cbuf/u_cbuf_ram_bank0_ram0/rmod/rmod_a
+        -> u_NV_NVDLA_cbuf.u_cbuf_ram_bank0_ram0.rmod.rmod_a
+    """
+    # Handle [N]. pattern (generate block mid-hierarchy)
+    name = re.sub(r'\[(\d+)\]\.', r'_\1__.', plc_name)
+    # Handle [N] at end of a segment before '/'
+    name = re.sub(r'\[(\d+)\](?=/|$)', r'_\1_', name)
+    # Hierarchy separator
+    name = name.replace('/', '.')
+    return name
+
+
 def write_orfs_macro_placement(placement, benchmark, plc, output_file, core_area=None):
     """
     Write macro placement in ORFS format using place_macro command.
@@ -169,6 +194,7 @@ def write_orfs_macro_placement(placement, benchmark, plc, output_file, core_area
 
     # Build placement data keyed by (group_prefix, flat_macro_index)
     group_data = defaultdict(dict)  # group_prefix -> {K: (x, y, orient, plc_name)}
+    direct_placements = []  # For non-Ariane designs: (odb_name, x, y, orient, plc_name)
     total_macros = 0
 
     for i, macro_idx in enumerate(benchmark.hard_macro_indices):
@@ -197,7 +223,10 @@ def write_orfs_macro_placement(placement, benchmark, plc, output_file, core_area
             group_data[group_prefix][macro_k] = (x_ll, y_ll, orientation, plc_name)
             total_macros += 1
         else:
-            print(f"  WARNING: Could not parse .plc name: {plc_name}")
+            # Fallback: convert plc name directly to ODB name (mempool_tile, nvdla, etc.)
+            odb_name = _plc_to_odb_name(plc_name)
+            direct_placements.append((odb_name, x_ll, y_ll, orientation, plc_name))
+            total_macros += 1
 
     with open(output_file, 'w') as f:
         f.write("# Macro Placement for OpenROAD-flow-scripts\n")
@@ -264,6 +293,23 @@ dict for {prefix entries} $_odb_groups {
 }
 
 """)
+
+        # Direct placements for non-Ariane designs (mempool_tile, nvdla, etc.)
+        if direct_placements:
+            f.write("# Direct placements (non-genblk naming)\n")
+            f.write("set block [ord::get_db_block]\n" if not group_data else "")
+            for odb_name, x_ll, y_ll, orient, plc_name in direct_placements:
+                odb_escaped = odb_name.replace('[', '\\[').replace(']', '\\]')
+                f.write(f'# {plc_name}\n')
+                f.write(f'set _inst [$block findInst "{odb_escaped}"]\n')
+                f.write(f'if {{$_inst ne "NULL"}} {{\n')
+                f.write(f'    place_macro -macro_name [list {odb_escaped}] -location [list {x_ll:.6f} {y_ll:.6f}] -orientation {orient}\n')
+                f.write(f'    incr _placed\n')
+                f.write(f'}} else {{\n')
+                f.write(f'    puts "WARNING: ODB instance not found: {odb_escaped}"\n')
+                f.write(f'}}\n')
+            f.write("\n")
+
         f.write(f'puts "Placed $_placed macros (expected {total_macros})"\n')
         f.write(f'if {{$_placed != {total_macros}}} {{\n')
         f.write(f'    puts "WARNING: Expected {total_macros} macros but placed $_placed"\n')
@@ -273,8 +319,10 @@ dict for {prefix entries} $_odb_groups {
         f.write('    }\n')
         f.write("}\n")
 
+    n_genblk = len(group_data)
+    n_direct = len(direct_placements)
     print(f"✓ Generated ORFS macro placement TCL: {output_file}")
-    print(f"  {total_macros} macros across {len(group_data)} sram groups")
+    print(f"  {total_macros} macros ({n_genblk} sram groups, {n_direct} direct placements)")
 
 
 def main():


### PR DESCRIPTION
## Summary
Fixes all three Tier 2 ORFS infrastructure bugs. Previously only ariane136 worked correctly.

**Fix #50 — ariane133 (89 SRAMs lost)**
- Override `SYNTH_NETLIST_FILES` to use the pre-mapped Genus gate netlist which has all 133 SRAMs
- Bypasses Yosys + PRESERVE_CELLS which was dropping all i_nbdcache SRAMs

**Fix #53 — mempool_tile (0/20 macros placed)**
- Added `_plc_to_odb_name()` fallback for non-Ariane naming conventions
- Converts plc hierarchy names to ODB flat names (`/` → `.`, `[N].` → `_N__`)
- Emits direct `place_macro` commands for macros that don't match the genblk pattern

**Fix #52 — nvdla (no ORFS config)**
- Generates ORFS config at runtime: config.mk, constraint.sdc, fakeram45_256x64 LEF/LIB
- 128 macros using fakeram45_256x64 from Enablements directory

Closes #50, closes #52, closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)