### PR TITLE
Expose pin-level net connectivity in Benchmark

### DIFF
--- a/macro_place/benchmark.py
+++ b/macro_place/benchmark.py
@@ -53,6 +53,21 @@ class Benchmark:
     # List of [num_pins_i, 2] tensors, one per hard macro (indices [0, num_hard_macros))
     macro_pin_offsets: List[torch.Tensor] = field(default_factory=list)
 
+    # Pin-level net connectivity (optional; empty list if not populated)
+    # Each net_pin_nodes[i] is an int64 tensor of shape [num_pins_in_net_i, 2] where:
+    #   column 0 = owner index:
+    #     - hard macros:  [0, num_hard_macros)
+    #     - soft macros:  [num_hard_macros, num_macros)
+    #     - I/O ports:    [num_macros, num_macros + num_ports)
+    #   column 1 = pin index within that owner:
+    #     - hard macro:   index into macro_pin_offsets[owner]
+    #     - soft macro:   always 0 (pins at macro center; soft macros carry no offsets)
+    #     - port:         always 0 (port is a single point at port_positions[owner-num_macros])
+    # Unlike net_nodes (which dedups to per-macro granularity), this preserves
+    # every pin endpoint — multiple pins on the same macro appear as multiple rows.
+    # Needed by placers computing pin-level HPWL for differentiable loss.
+    net_pin_nodes: List[torch.Tensor] = field(default_factory=list)
+
     # Routing parameters
     hroutes_per_micron: float = 11.285  # Horizontal routing tracks per micron
     vroutes_per_micron: float = 12.605  # Vertical routing tracks per micron
@@ -91,6 +106,11 @@ class Benchmark:
                 f"len(net_nodes) {len(self.net_nodes)} != num_nets {self.num_nets}"
             )
 
+        if len(self.net_pin_nodes) > 0:
+            assert len(self.net_pin_nodes) == self.num_nets, (
+                f"len(net_pin_nodes) {len(self.net_pin_nodes)} != num_nets {self.num_nets}"
+            )
+
         assert self.net_weights.shape == (self.num_nets,), (
             f"net_weights shape {self.net_weights.shape} != ({self.num_nets},)"
         )
@@ -118,6 +138,7 @@ class Benchmark:
                 "vroutes_per_micron": self.vroutes_per_micron,
                 "port_positions": self.port_positions,
                 "macro_pin_offsets": self.macro_pin_offsets,
+                "net_pin_nodes": self.net_pin_nodes,
                 "hard_macro_indices": self.hard_macro_indices,
                 "soft_macro_indices": self.soft_macro_indices,
             },
@@ -138,6 +159,8 @@ class Benchmark:
             data["port_positions"] = torch.zeros(0, 2)
         if "macro_pin_offsets" not in data:
             data["macro_pin_offsets"] = []
+        if "net_pin_nodes" not in data:
+            data["net_pin_nodes"] = []
         return cls(**data)
 
     def get_movable_mask(self) -> torch.Tensor:

--- a/macro_place/loader.py
+++ b/macro_place/loader.py
@@ -89,16 +89,20 @@ def load_benchmark(
 
     num_macros = num_hard + num_soft
 
-    # Extract hard macro pin offsets (relative to macro center)
+    # Extract hard macro pin offsets (relative to macro center).
+    # Also build pin_slot: full pin name ("MACRO/PIN") -> (macro_name, slot_in_macro)
+    # so we can map net membership to specific pin offsets (needed for pin-level HPWL).
     macro_pin_offsets = []
-    pin_map = {}
+    pin_map = {}          # macro_name -> list of [x_offset, y_offset]
+    pin_slot = {}         # "MACRO/PIN" -> (macro_name, slot index into pin_map[macro_name])
     for idx in plc.hard_macro_pin_indices:
         pin = plc.modules_w_pins[idx]
         pin_macro = pin.get_macro_name() if hasattr(pin, "get_macro_name") else None
         if pin_macro:
-            pin_map.setdefault(pin_macro, []).append(
-                [pin.x_offset, pin.y_offset]
-            )
+            slot = len(pin_map.setdefault(pin_macro, []))
+            pin_map[pin_macro].append([pin.x_offset, pin.y_offset])
+            if hasattr(pin, "get_name"):
+                pin_slot[pin.get_name()] = (pin_macro, slot)
     for macro_idx in hard_macro_plc_indices:
         macro_name = plc.modules_w_pins[macro_idx].get_name()
         offsets = pin_map.get(macro_name, [])
@@ -143,16 +147,30 @@ def load_benchmark(
 
     num_nets = int(plc.net_cnt)
     net_nodes = []
+    net_pin_nodes = []
     net_weights_list = []
     for driver, sinks in plc.nets.items():
+        pins_in_net = []  # list of [owner_bench_idx, pin_slot]
         nodes_in_net = set()
         for pin_name in [driver] + sinks:
-            # Pin names are "MACRO/PIN" for macro pins or just "PORT" for ports
-            parent = pin_name.split("/")[0]
-            if parent in name_to_bench:
-                nodes_in_net.add(name_to_bench[parent])
+            # Pin names are "MACRO/PIN" for macro pins or just "PORT" for ports.
+            # For hard-macro pins we resolve to the exact offset slot; for soft
+            # macros and ports (which carry no per-pin offsets here) we use slot 0.
+            if pin_name in pin_slot:
+                macro_name, slot = pin_slot[pin_name]
+                if macro_name in name_to_bench:
+                    owner = name_to_bench[macro_name]
+                    pins_in_net.append([owner, slot])
+                    nodes_in_net.add(owner)
+            else:
+                parent = pin_name.split("/")[0]
+                if parent in name_to_bench:
+                    owner = name_to_bench[parent]
+                    pins_in_net.append([owner, 0])
+                    nodes_in_net.add(owner)
         if nodes_in_net:
             net_nodes.append(torch.tensor(sorted(nodes_in_net), dtype=torch.long))
+            net_pin_nodes.append(torch.tensor(pins_in_net, dtype=torch.long))
             net_weights_list.append(1.0)
 
     num_nets = len(net_nodes)
@@ -179,6 +197,7 @@ def load_benchmark(
         vroutes_per_micron=vroutes_per_micron,
         port_positions=port_positions,
         macro_pin_offsets=macro_pin_offsets,
+        net_pin_nodes=net_pin_nodes,
         hard_macro_indices=hard_macro_plc_indices,
         soft_macro_indices=soft_macro_plc_indices,
     )

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -61,6 +61,55 @@ def test_validate_placement(ibm01):
     assert isinstance(violations, list)
 
 
+def test_net_pin_nodes(ibm01):
+    """Loader exposes pin-level net connectivity consistent with net_nodes."""
+    import torch
+
+    benchmark, _ = ibm01
+    assert len(benchmark.net_pin_nodes) == benchmark.num_nets
+
+    for net_id, (net_pins, net_owners) in enumerate(
+        zip(benchmark.net_pin_nodes, benchmark.net_nodes)
+    ):
+        # Shape: [pins_in_net, 2] — columns are (owner_idx, pin_slot)
+        assert net_pins.ndim == 2 and net_pins.shape[1] == 2, (
+            f"net {net_id}: net_pins shape {net_pins.shape}"
+        )
+
+        # Dedup+sort of owner column must match existing net_nodes exactly
+        owners_sorted = torch.unique(net_pins[:, 0]).sort().values
+        assert torch.equal(owners_sorted, net_owners), (
+            f"net {net_id}: owners {owners_sorted.tolist()} != net_nodes {net_owners.tolist()}"
+        )
+
+        # Pin slots must index into macro_pin_offsets[owner] for hard macros
+        for owner, slot in net_pins.tolist():
+            if owner < benchmark.num_hard_macros:
+                num_pins_on_macro = benchmark.macro_pin_offsets[owner].shape[0]
+                assert slot < num_pins_on_macro, (
+                    f"net {net_id}: owner {owner} slot {slot} >= "
+                    f"macro_pin_offsets[{owner}].shape[0] {num_pins_on_macro}"
+                )
+            else:
+                assert slot == 0, (
+                    f"net {net_id}: non-hard-macro owner {owner} must use slot 0, got {slot}"
+                )
+
+
+def test_benchmark_save_load_roundtrip(ibm01, tmp_path):
+    """Benchmark.save/load preserves net_pin_nodes."""
+    import torch
+
+    benchmark, _ = ibm01
+    out = tmp_path / "roundtrip.pt"
+    benchmark.save(str(out))
+    loaded = Benchmark.load(str(out))
+
+    assert len(loaded.net_pin_nodes) == len(benchmark.net_pin_nodes)
+    for a, b in zip(loaded.net_pin_nodes, benchmark.net_pin_nodes):
+        assert torch.equal(a, b)
+
+
 def test_greedy_row_placer(ibm01):
     """Greedy row placer produces a valid, zero-overlap placement."""
     import importlib.util


### PR DESCRIPTION
## Summary
The `Benchmark` object collapsed `MACRO/PIN` endpoints from `plc.nets` down to per-macro granularity (`loader.py` split pin names on `/` and deduped via a `set`). Placers computing pin-level HPWL for a differentiable loss had to re-parse `netlist.pb.txt` themselves to recover the information — as Tobias Franks (ByteDancer / Incremental CD) pointed out.

This adds pin-level net connectivity to `Benchmark` while preserving `net_nodes` for backwards compatibility.

## Changes
- **`macro_place/benchmark.py`**: New field `net_pin_nodes: List[Tensor]`. Each entry is shape `[pins_in_net, 2]` with columns `(owner_idx, pin_slot)`. For hard macros, `pin_slot` indexes into `macro_pin_offsets[owner]`; for soft macros and I/O ports, `pin_slot` is always `0`.
- **`macro_place/loader.py`**: Builds a `pin_name → (macro_name, slot)` map while extracting `macro_pin_offsets`, then uses it in the net-parsing loop to resolve each `MACRO/PIN` string to its exact offset slot. Populates both `net_nodes` (unchanged semantics) and `net_pin_nodes` in the same pass.
- **`test/test_smoke.py`**: Adds `test_net_pin_nodes` (validates shape, consistency with `net_nodes`, and slot ranges) and `test_benchmark_save_load_roundtrip`.

## Backwards compatibility
- `net_nodes` is unchanged. Dedup+sort of `net_pin_nodes[:, 0]` equals `net_nodes` for every net (asserted).
- `Benchmark.save` / `Benchmark.load` round-trip the new field.
- Old `.pt` files load with `net_pin_nodes = []` — run `scripts/convert_ibm_benchmarks.py` to regenerate with pin-level info populated.
- The main eval harness (`macro_place/evaluate.py`) already calls `load_benchmark_from_dir`, so submissions see fully populated `net_pin_nodes` immediately with no migration needed.

## Test plan
- [x] `pytest test/test_smoke.py` — all 7 tests pass (5 existing + 2 new)
- [x] Manual HPWL reconstruction from `net_pin_nodes` on ibm01 (5993 nets, 16815 pin endpoints) and ibm10 (28272 nets, 80293 pin endpoints) — pin slot indices all in range, owner dedup matches `net_nodes` exactly
- [ ] Someone using pin-level HPWL in their placer (Tobias / ByteDancer) confirms the new field is sufficient for their use case

🤖 Generated with [Claude Code](https://claude.com/claude-code)