### PR TITLE
Clarify orientation/soft-resize rulings; fix SCORING.md Step 2 formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Partcl develops GPU-accelerated systems for physical design that run orders of m
 - **Swag:** Every valid submission gets HRT swag!
 - **Note:** An additional score adjustment will be applied based on human-expert analysis of the resulting placement.
 
+For full Grand Prize scoring rules, feasibility gate, tie-breaking, and ORFS-failure handling, see [`SCORING.md`](SCORING.md).
+
 ## Submission Format
 
 - All submissions will be via google form. Submissions may be made public or private before the end of judging.
@@ -78,6 +80,7 @@ Partcl develops GPU-accelerated systems for physical design that run orders of m
 - **Any framework**: PyTorch, TensorFlow, JAX, or pure Python/C++
 - **Any optimization technique**: Gradient descent, evolutionary algorithms, local search, etc.
 - **Training on public benchmarks**: You can learn from the IBM benchmark data
+- **Hard-macro orientation flips** (Klein-4 only: `N`, `FN`, `FS`, `S`) — carried to Tier 2 via an optional `orientations.pt` sidecar
 
 ### Not Allowed
 
@@ -86,6 +89,8 @@ Partcl develops GPU-accelerated systems for physical design that run orders of m
 - Using external/proprietary placement tools (must be open-source submission)
 - Exceeding runtime limits (1 hour per benchmark hard timeout)
 - Overlaps in resulting placement (strictly zero overlap between hard macros — no tolerance. Participants should add small gaps in their legalization to avoid float-precision edge cases.)
+- 90° rotations of hard macros (`R90`, `R270`, `FE`, `FW`) — the fakeram45 SRAMs in our benchmarks aren't designed for rotation (pin access and internal metal direction assume a fixed orientation)
+- Resizing soft macros — soft-macro size is a proxy-only concept for density/congestion that doesn't translate to Tier 2; sizes are locked to the initial `.plc` values on every `compute_proxy_cost` call
 
 ## Evaluation Details
 

--- a/SCORING.md
+++ b/SCORING.md
@@ -109,9 +109,9 @@ Area_avg = (Area_SA + Area_RP) / 2
 For each design:
 
 ```
-R_WNS  = WNS_sub  / WNS_avg       (both values are negative; ratio > 1 means better)
-R_TNS  = TNS_sub  / TNS_avg       (both values are negative; ratio > 1 means better)
-R_Area = Area_avg / Area_sub      (lower area is better, so invert)
+R_WNS  = WNS_avg  / WNS_sub       (both negative; less-negative numerator is the baseline, so ratio > 1 means submission is better)
+R_TNS  = TNS_avg  / TNS_sub       (both negative; ratio > 1 means submission is better)
+R_Area = Area_avg / Area_sub      (lower area is better, so avg over sub; ratio > 1 means submission is smaller)
 ```
 
 ### Step 3 — Compute Per-Design Score
@@ -150,24 +150,9 @@ Suppose for `ariane133`:
 - Submission: WNS = -0.8 ns, TNS = -6,000 ns, Area = 4,000,000 μm²
 
 ```
-R_WNS  = -0.8 / -1.3 = 0.615   → less negative = better, but ratio < 1?
-```
-
-**Wait — important note on WNS/TNS ratio interpretation:**
-
-Since WNS and TNS are negative values (slack violations), a *less negative* value is better. When dividing two negative numbers, a less negative numerator (better) over a more negative denominator gives a ratio **less than 1**. To make the ratio intuitive (> 1 = better):
-
-```
-R_WNS  = WNS_avg / WNS_sub       (flipped: avg over submission)
-R_TNS  = TNS_avg / TNS_sub       (flipped: avg over submission)
-R_Area = Area_avg / Area_sub     (avg over submission)
-```
-
-Corrected example:
-```
-R_WNS  = -1.3 / -0.8  = 1.625   (62.5% better WNS)
-R_TNS  = -10000 / -6000 = 1.667  (66.7% better TNS)
-R_Area = 4200000 / 4000000 = 1.05 (5% smaller area)
+R_WNS  = -1.3    / -0.8     = 1.625   (62.5% better WNS)
+R_TNS  = -10000  / -6000    = 1.667   (66.7% better TNS)
+R_Area = 4200000 / 4000000  = 1.050   (5% smaller area)
 
 Design_Score = (1.625^3 × 1.667^2 × 1.05^1) ^ (1/6)
              = (4.291 × 2.779 × 1.05) ^ (1/6)


### PR DESCRIPTION
## Summary

**README:**
- Add [`SCORING.md`](SCORING.md) pointer under the Prizes section for Grand Prize scoring rules, feasibility gate, tie-breaking, and ORFS-failure handling.
- **Allowed**: Klein-4 hard-macro orientation flips (\`N\`, \`FN\`, \`FS\`, \`S\`), carried to Tier 2 via an optional \`orientations.pt\` sidecar.
- **Not allowed**: 90° rotations of hard macros (\`R90\`, \`R270\`, \`FE\`, \`FW\`). The fakeram45 SRAMs in our benchmarks aren't designed for rotation.
- **Not allowed**: soft-macro resizing. Soft-macro size is a proxy-only concept for density/congestion that doesn't translate to Tier 2 PPA; sizes are locked to the initial \`.plc\` values on every \`compute_proxy_cost\` call.

**SCORING.md fixes (#66):**
- Step 2 formula was arithmetically wrong: \`R_WNS = WNS_sub / WNS_avg\` with \"ratio > 1 means better\" — but for negative slacks, better/worse gives a ratio < 1. Corrected to \`R_WNS = WNS_avg / WNS_sub\` so the ratio-as-improvement convention actually holds.
- Removed the \"Wait — important note\" mid-document correction artifact that Cezar spotted. The example now just shows the ratios and the weighted geometric mean directly.

Closes #54, #66.

The evaluator-side code changes (orientation sidecar apply-step, soft-macro size lock) will ship in follow-up PRs.

## Test plan
- [x] \`SCORING.md\` renders cleanly; Step 2 and Example are internally consistent (R_WNS = -1.3 / -0.8 = 1.625 → design score 1.524)
- [x] README renders cleanly with new Allowed/Not Allowed bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)