### PR TITLE
Leaderboard 5/4: 5 new entries + 7 resubmits, consolidate chuanqi.chen entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,37 +230,42 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 
 | Rank | Team | Avg Proxy Cost | Best | Worst | Overlaps | Runtime | Verified | Notes |
 |------|------|---------------|------|-------|----------|---------|----------|-------|
-| 1 | "Cezar" (ReFine) | **1.2224** | 0.8843 | 1.5115 | 0 | 5min/bench | :white_check_mark: | Verified 1.2224 vs self-reported 1.0666; beats RePlAce by 16.2%, SA by 42.5%; resubmitted 4/25, contesting result — re-verification pending |
-| 2 | "MTK" (DreamPlace++) | **1.2818** | 0.9073 | 1.6529 | 0 | 37s/bench (GPU) | :white_check_mark: | Verified better than self-reported 1.317; beats RePlAce on all 17 benchmarks |
-| 3 | "RoRa" (RipPlace) | **1.3241** | — | — | 0 | 694s/bench | | |
-| 4 | "UToronto Analytical" (MOSAIC) | **1.3323** | 0.9371 | 1.6545 | 0 | 24min total | :white_check_mark: | Verified 1.3323 (self-reported 1.3325 — exact match); gradient-based with smooth surrogates, hard+soft |
-| 5 | "Shoom" (MultiDREAMPlace) | **1.3381** | — | — | 0 | 350s/bench | | New 4/27; multi-start DREAMPlace + min-displacement legalization + SA |
-| 6 | "V5" (TierPlace) | **1.3382** | — | — | 0 | 850s/bench | | New 4/23; GPU-based, multi-density-formulation pilot + phased optimization |
-| 7 | "Archgen" (AutoDMP++) | **1.3479** | — | — | 0 | 2404s total | | New 4/24; multi-start + fast proxy screening + bounded refinement |
-| 8 | "Electric Beatel" (ePlace-Lite) | **1.3913** | 0.9773 | 1.7253 | 0 | 155s/bench (GPU) | :white_check_mark: | |
-| 9 | "Varun's Parallel Worlds" (GRPlace) | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: | |
-| 10 | "UT Austin" - AS (DREAMPlace Analytical) | **1.4076** | — | — | 0 | 17s/bench | | |
-| 11 | "ByteDancer" (Incremental CD) | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: | |
-| 12 | "vmallela" (Incremental CD+LNS) | **1.4152** | 1.0236 | 1.7817 | 0 | 12h total | :white_check_mark: | Verified 1.4152 (self-reported 1.1172 — 27% worse on our hardware); pure Python+numpy, single-threaded |
-| 13 | "TAISPlAce" (ALNS + Thompson Sampling) | **1.4321** | — | — | 0 | 28min/bench | | |
-| 14 | "ArzunPD" (HyperPlace SA+LNS) | **1.4421** | 1.0323 | 1.7851 | 0 | 6h total | :white_check_mark: | Verified 1.4421 (self-reported 1.4174); Stage 5 LNS disabled — missing `networkit` dep, fell back to Stage 4 across all benchmarks |
-| 15 | "Pragnay" (SweepingBellPlacement) | **1.4427** | — | — | 0 | 632s/bench | | |
-| 16 | "Convex Optimization" (UWaterloo Student) | **1.4556** | 1.0432 | 1.7867 | 0 | 11s/bench | :white_check_mark: | Resubmitted 4/13; fixed from DQ (was 846 overlaps) |
-| 17 | "another Waterloo kid" (Batched Nesterov GP) | **1.4568** | — | — | 0 | 118s/bench | | |
+| 1 | "Cezar" (ReFine) | **1.037** | — | — | 0 | 55min/bench | | Resubmitted 5/3; new approach (DREAMPlace-style differentiable refinement, normal .py instead of obfuscated). Previous ReFine variant was verified 1.2224 vs self-reported 1.0666. Re-verification pending. |
+| 2 | "vmallela" (LSJ) | **1.1** | — | — | 0 | 40min/bench | | Resubmitted 5/3 (Hessian negative-eigenvalue saddle escape branch). Previous Incremental CD+LNS verified at 1.4152 vs self-reported 1.1172. Re-verification pending. |
+| 3 | "Hoop Dreams" (DREAMTuna) | **1.2206** | — | — | 0 | 20min/bench | | New 5/1; DREAMPlace + Bayesian optimization (Optuna) hyperparameter sweep |
+| 4 | "Shoom" (MultiDreamPlace v2) | **1.2353** | — | — | 0 | 42min/bench | | Resubmitted 5/1 with multi-start + fine tuning (was 1.3381) |
+| 5 | "KLA MACH" (ProxCD) | **1.2355** | — | — | 0 | 10.6min/bench | | New (consolidates UTDA / Chuanqi Chen / KLA MACH submissions from 4/30–5/2; latest is Phase 20 ProxCD: numpy/Numba proxy + multi-start coordinate descent + LNS) |
+| 6 | "ArzunPD" (MacroWeave SA+LNS) | **1.2478** | — | — | 0 | 55min/bench | | Resubmitted 5/1 (was HyperPlace, verified 1.4421 with networkit-disabled Stage 5). Re-verification pending. |
+| 7 | "RoRa" (RoomPlace) | **1.2723** | — | — | 0 | ~700s/bench | | Resubmitted 5/1 (canvas-shrink approach); previous RipPlace was blocked on `place(plc=...)` signature. Re-verification pending. |
+| 8 | "William Zhang" (RePlAce++) | **1.2767** | — | — | 0 | 259s/bench | | Resubmitted 5/2 (was "Convex Optimization", verified 1.4556); RePlAce-backed candidate portfolio with proxy-objective selection. Re-verification pending. |
+| 9 | "MTK" (DreamPlace++) | **1.2818** | 0.9073 | 1.6529 | 0 | 37s/bench (GPU) | :white_check_mark: | Verified better than self-reported 1.317; beats RePlAce on all 17 benchmarks |
+| 10 | "Electric Beatle" (ePlace-Lite) | **1.3253** | — | — | 0 | 2000s/bench (GPU) | | Resubmitted 4/30 (was verified 1.3913); Adam-based stochastic descent + multi-start hyperparameter sweep. Re-verification pending. |
+| 11 | "UToronto Analytical" (MOSAIC) | **1.3323** | 0.9371 | 1.6545 | 0 | 24min total | :white_check_mark: | Verified 1.3323 (self-reported 1.3325 — exact match); gradient-based with smooth surrogates, hard+soft |
+| 12 | "V5" (TierPlace) | **1.3382** | — | — | 0 | 850s/bench | | New 4/23; GPU-based, multi-density-formulation pilot + phased optimization |
+| 13 | "Archgen" (AutoDMP++) | **1.3479** | — | — | 0 | 2404s total | | New 4/24; multi-start + fast proxy screening + bounded refinement |
+| 14 | "RUDY Can't Fail" (Fast Proxy CD) | **1.3605** | — | — | 0 | 111s/bench | | New 5/3; SA → Adam GD → legalization → coordinate descent with 0.4ms incremental evaluator |
+| 15 | "Varun's Parallel Worlds" (GRPlace) | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: | |
+| 16 | "UT Austin" - AS (DREAMPlace Analytical) | **1.4076** | — | — | 0 | 17s/bench | | |
+| 17 | "ByteDancer" (Incremental CD) | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: | |
+| 18 | "TAISPlAce" (ALNS + Thompson Sampling) | **1.4321** | — | — | 0 | 28min/bench | | |
+| 19 | "Two-IIITK-Kids" (Proximal-Gradient Analytical) | **1.436** | — | — | 0 | 38min/bench | | New 5/2, resubmitted 5/4; PyTorch RePlAce-style + native C++ SA seed generation |
+| 20 | "Pragnay" (SweepingBellPlacement) | **1.4427** | — | — | 0 | 632s/bench | | Blocked on `compute_proxy_cost(..., plc=None)` in fallback path |
+| 21 | "No Man's Sky" (ALNS-MOS) | **1.4445** | — | — | 0 | 8.8min/bench | | New 5/4; Adaptive Large Neighborhood Search with multi-operator destroy/repair |
+| 22 | "another Waterloo kid" (Batched Nesterov GP) | **1.4568** | — | — | 0 | 118s/bench | | Blocked on Modal cloud dispatch — can't run air-gapped |
 | — | RePlAce (baseline) | **1.4578** | 0.9976 | 1.8370 | 0 | — | :white_check_mark: | |
-| 18 | "W3 Solutions" (GRACE) | **1.4824** | — | — | 0 | 90s/bench | | |
-| 19 | "Jiangban Ya" (Spectral-Seed + Adaptive Legalizer) | **1.4943** | 1.0891 | 1.8099 | 0 | 49s/bench | :white_check_mark: | |
-| 20 | "UTAUSTIN-CT" (PLC-Exact Congestion-Aware SA) | **1.5062** | 1.1363 | 1.7941 | 0 | 6s/bench | :white_check_mark: | |
-| 21 | "oracleX" (Oracle) | **1.5130** | 1.1340 | 1.7937 | 0 | 11s/bench | :white_check_mark: | |
-| 22 | "SEVmakers" (Hybrid Legalization + SA) | **1.5200** | — | — | 0 | 200s/bench | | Private repo — pending judge access |
-| 23 | "CA" (congestion_aware) | **1.5247** | 1.2226 | 1.7945 | 0 | 2s/bench | :white_check_mark: | Verified 1.5247 vs self-reported 1.5238 |
-| 24 | "#5 ubc cpen student" (Gene Pool Shuffle) | **1.5337** | 1.1411 | 1.8084 | 0 | 13s/bench | :white_check_mark: | |
-| 25 | Will Seed (Partcl) | **1.5338** | 1.1625 | 1.7965 | 0 | 35s total | :white_check_mark: | |
-| 26 | "UT Austin" - RH (DREAMPlace) | **1.6037** | — | — | 0 | 4.5s/bench | | |
-| 27 | "UT Austin" - CT (PROXYCost) | **1.8706** | — | — | 0 | 187s/bench | | |
-| 28 | "AS" (Shelf Stacker) | **1.9121** | 1.4614 | 2.3508 | 0 | 0.16s total | :white_check_mark: | |
-| 29 | "Adi's Team" (GNN-ePlace Hybrid) | **2.0025** | — | — | 0 | 3726s/bench | | |
-| 30 | "Sharc #1" (Auction Placer) | **2.0433** | 1.5143 | 2.4336 | 0 | 96s/bench | :white_check_mark: | |
+| 23 | "W3 Solutions" (GRACE) | **1.4824** | — | — | 0 | 90s/bench | | HybridPlacer runtime exceeds 1h/bench cap on our hardware |
+| 24 | "Jiangban Ya" (Spectral-Seed + Adaptive Legalizer) | **1.4943** | 1.0891 | 1.8099 | 0 | 49s/bench | :white_check_mark: | |
+| 25 | "UTAUSTIN-CT" (PLC-Exact Congestion-Aware SA) | **1.5062** | 1.1363 | 1.7941 | 0 | 6s/bench | :white_check_mark: | |
+| 26 | "oracleX" (Oracle) | **1.5130** | 1.1340 | 1.7937 | 0 | 11s/bench | :white_check_mark: | |
+| 27 | "SEVmakers" (Hybrid Legalization + SA) | **1.5200** | — | — | 0 | 200s/bench | | Private repo — pending judge access |
+| 28 | "CA" (congestion_aware) | **1.5247** | 1.2226 | 1.7945 | 0 | 2s/bench | :white_check_mark: | Verified 1.5247 vs self-reported 1.5238 |
+| 29 | "#5 ubc cpen student" (Gene Pool Shuffle) | **1.5337** | 1.1411 | 1.8084 | 0 | 13s/bench | :white_check_mark: | |
+| 30 | Will Seed (Partcl) | **1.5338** | 1.1625 | 1.7965 | 0 | 35s total | :white_check_mark: | |
+| 31 | "UT Austin" - RH (DREAMPlace) | **1.6037** | — | — | 0 | 4.5s/bench | | |
+| 32 | "UT Austin" - CT (PROXYCost) | **1.8706** | — | — | 0 | 187s/bench | | |
+| 33 | "AS" (Shelf Stacker) | **1.9121** | 1.4614 | 2.3508 | 0 | 0.16s total | :white_check_mark: | |
+| 34 | "Adi's Team" (GNN-ePlace Hybrid) | **2.0025** | — | — | 0 | 3726s/bench | | Blocked on `compute_proxy_cost(skip_congestion=True)` kwarg |
+| 35 | "Sharc #1" (Auction Placer) | **2.0433** | 1.5143 | 2.4336 | 0 | 96s/bench | :white_check_mark: | |
 | — | SA (baseline) | 2.1251 | 1.3166 | 3.6726 | 0 | — | :white_check_mark: | |
 | — | Greedy Row (demo) | 2.2109 | 1.6728 | 2.7696 | 0 | 0.3s total | :white_check_mark: | |
 | — | "Binghamton" (feng shui) | pending | — | — | — | — | | |


### PR DESCRIPTION
## Summary

**New entries:**
- **Hoop Dreams** (DREAMTuna) — 1.2206, DREAMPlace + Optuna BO. Rank 3.
- **KLA MACH** (ProxCD) — 1.2355. **Consolidates** all chuanqi.chen@utexas.edu submissions (UTDA Phase 11/12/13/16/18 + Chuanqi Chen Phase 14 + KLA MACH Phase 20) into a single row at the latest team name + score, per the "one algorithm per team" rule. Rank 5.
- **RUDY Can't Fail** — 1.3605, SA → Adam GD → CD with fast incremental proxy. Rank 14.
- **Two-IIITK-Kids** — 1.436, PyTorch RePlAce-style + native C++ SA. Rank 19.
- **No Man's Sky** — 1.4445, ALNS with multi-operator search. Rank 21.

**Resubmissions** (verified marker dropped, replaced with new self-reported, previous verified value kept in note):
| Team | New | Previous |
|---|---|---|
| Cezar (ReFine v2 5/3) | 1.037 | verified 1.2224 |
| vmallela (LSJ 5/3) | 1.1 | verified 1.4152 |
| Shoom (MultiDreamPlace v2 5/1) | 1.2353 | 1.3381 |
| ArzunPD (MacroWeave 5/1) | 1.2478 | verified 1.4421 |
| RoRa (RoomPlace 5/1) | 1.2723 | 1.3241 (blocked) |
| William Zhang (RePlAce++ 5/2) | 1.2767 | verified 1.4556 |
| Electric Beatle (resubmit 4/30) | 1.3253 | verified 1.3913 |

**Note on the chuanqi consolidation**: same author submitted seven times across three team names; the form is the canonical record but allows one algorithm per team, so I'm taking the latest submission's name (KLA MACH) and score (Phase 20 / 1.2355). If you'd rather treat them as separate teams or take a different consolidation, let me know.

## Test plan
- [x] Leaderboard renders cleanly
- [x] Ranks consistent with avg-proxy ordering
- [ ] Verification runs on the seven resubmitted entries (separate work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)