### PR TITLE
Fix Tier 2 coordinate mapping: center-offset instead of scaling

### DIFF
--- a/scripts/generate_macro_placement_tcl.py
+++ b/scripts/generate_macro_placement_tcl.py
@@ -192,20 +192,22 @@ def write_orfs_macro_placement(placement, benchmark, plc, output_file, core_area
 
     placement_np = placement.cpu().numpy()
 
-    # Compute scale factors from proxy canvas to ORFS core
+    # Map proxy canvas coordinates to ORFS core area.
+    # Center-offset (no scaling) to preserve macro-to-macro distances exactly.
+    # The ORFS core is larger than the proxy canvas — extra space is used by
+    # standard cells and routing.
     canvas_w = float(benchmark.canvas_width)
     canvas_h = float(benchmark.canvas_height)
     if core_area is not None:
         core_x_min, core_y_min, core_x_max, core_y_max = core_area
         core_w = core_x_max - core_x_min
         core_h = core_y_max - core_y_min
-        scale_x = core_w / canvas_w
-        scale_y = core_h / canvas_h
-        offset_x = core_x_min
-        offset_y = core_y_min
+        # Center the proxy canvas within the ORFS core (no scaling)
+        offset_x = core_x_min + (core_w - canvas_w) / 2
+        offset_y = core_y_min + (core_h - canvas_h) / 2
         print(f"  Proxy canvas: {canvas_w:.1f} x {canvas_h:.1f}")
-        print(f"  ORFS core:    {core_w:.1f} x {core_h:.1f} (offset {offset_x:.1f}, {offset_y:.1f})")
-        print(f"  Scale factors: {scale_x:.4f} x {scale_y:.4f}")
+        print(f"  ORFS core:    {core_w:.1f} x {core_h:.1f}")
+        print(f"  Center offset: ({offset_x:.1f}, {offset_y:.1f}) — no scaling, preserving distances")
 
     # Build placement data keyed by (group_prefix, flat_macro_index)
     group_data = defaultdict(dict)  # group_prefix -> {K: (x, y, orient, plc_name)}
@@ -222,16 +224,19 @@ def write_orfs_macro_placement(placement, benchmark, plc, output_file, core_area
         y_ll = y - h / 2
 
         if core_area is not None:
-            # Scale proxy coordinates to ORFS core area
-            x_ll = x_ll * scale_x + offset_x
-            y_ll = y_ll * scale_y + offset_y
+            # Center-offset proxy coordinates into ORFS core (no scaling)
+            x_ll = x_ll + offset_x
+            y_ll = y_ll + offset_y
             # Clamp to core bounds with margin for PDN channels
-            # (macro sizes are physical — not scaled)
             margin = 2.0
             x_ll = max(core_x_min + margin, min(x_ll, core_x_max - w - margin))
             y_ll = max(core_y_min + margin, min(y_ll, core_y_max - h - margin))
 
         orientation = node.get_orientation() if node.get_orientation() else "R0"
+        # Map compass orientations (from .plc) to ODB-native (for OpenROAD)
+        orientation = {'N': 'R0', 'S': 'R180', 'E': 'R270', 'W': 'R90',
+                       'FN': 'MY', 'FS': 'MX', 'FE': 'MYR90', 'FW': 'MXR90'
+                       }.get(orientation, orientation)
 
         if use_genus_names:
             # ODB always flattens to underscores regardless of netlist source


### PR DESCRIPTION
## Summary

**Breaking change for Tier 2 evaluation.** Previously, proxy canvas coordinates were scaled to fill the ORFS core area (1.4-2.25x stretch). This distorted macro-to-macro distances and hurt timing quality.

Now: proxy placements are **center-offset** into the ORFS core with **no scaling**. Macro-to-macro distances are preserved exactly. The extra ORFS die space is used by standard cells and routing.

Also adds compass→ODB orientation mapping (N→R0, S→R180, etc.) for .plc files. Credit: Billy Lee (MTK).

## Test plan
- [ ] Re-run ariane136 through ORFS with the new mapping
- [ ] Verify macros place correctly (Placed N macros = expected N)
- [ ] Verify PDN passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)