### PR TITLE
Strip implementation details from leaderboard (cherry-pick)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,48 +230,48 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 
 | Rank | Team | Avg Proxy Cost | Best | Worst | Overlaps | Runtime | Verified | Notes |
 |------|------|---------------|------|-------|----------|---------|----------|-------|
-| 1 | "vmallela" (LSJ) | **1.0109** | 0.7644 | 1.2921 | 0 | 15.5h total | :white_check_mark: | Verified 1.0109 (self-reported 1.1 — 8.1% BETTER than self-reported). Wins all 17 benchmarks vs every other verified entry. Hessian negative-eigenvalue saddle escape (`vmallela_v7` branch). Previous Incremental CD+LNS verified 1.4152. |
-| 2 | "Cezar" (ReFine) | **1.037** | — | — | 0 | 55min/bench | | Resubmitted 5/3; new approach (DREAMPlace-style differentiable refinement, normal .py instead of obfuscated). Previous ReFine variant was verified 1.2224 vs self-reported 1.0666. Re-verification pending. |
-| 3 | "KLA MACH" (ProxCD) | **1.2121** | 0.8527 | 1.6532 | 0 | 2h15min total | :white_check_mark: | Verified 1.2121 (self-reported 1.2355 — 1.9% better than self-report). Phase 20 ProxCD: numpy/Numba proxy + multi-start coordinate descent + LNS. Consolidates all chuanqi.chen submissions (UTDA / Chuanqi Chen / KLA MACH). |
-| 4 | "Hoop Dreams" (DREAMTuna) | **1.2206** | — | — | 0 | 20min/bench | | New 5/1; DREAMPlace + Bayesian optimization (Optuna) hyperparameter sweep |
-| 5 | "Shoom" (MultiDreamPlace v2) | **1.2353** | — | — | 0 | 42min/bench | | Resubmitted 5/1 with multi-start + fine tuning (was 1.3381) |
-| 6 | "ArzunPD" (MacroWeave SA+LNS) | **1.2478** | — | — | 0 | 55min/bench | | Resubmitted 5/1 (was HyperPlace, verified 1.4421 with networkit-disabled Stage 5). Re-verification pending. |
-| 7 | "RoRa" (RoomPlace) | **1.2788** | 0.9577 | 1.6222 | 0 | 2.6h total | :white_check_mark: | Verified 1.2788 (self-reported 1.2723 — 0.5% match); resubmitted 5/1 with canvas-shrink approach (previous RipPlace was blocked on `place(plc=...)` signature) |
-| 8 | "William Zhang" (RePlAce++) | **1.2767** | — | — | 0 | 259s/bench | | Resubmitted 5/2 (was "Convex Optimization", verified 1.4556); blocked on missing `casadi` module in eval container. Re-verification pending fix. |
-| 9 | "MTK" (DreamPlace++) | **1.2818** | 0.9073 | 1.6529 | 0 | 37s/bench (GPU) | :white_check_mark: | Verified better than self-reported 1.317; beats RePlAce on all 17 benchmarks |
-| 10 | "Electric Beatle" (ePlace-Lite) | **1.3253** | — | — | 0 | 2000s/bench (GPU) | | Resubmitted 4/30 (was verified 1.3913); Adam-based stochastic descent + multi-start hyperparameter sweep. Re-verification pending. |
-| 11 | "UToronto Analytical" (MOSAIC) | **1.3323** | 0.9371 | 1.6545 | 0 | 24min total | :white_check_mark: | Verified 1.3323 (self-reported 1.3325 — exact match); gradient-based with smooth surrogates, hard+soft |
-| 12 | "V5" (TierPlace) | **1.3382** | — | — | 0 | 850s/bench | | New 4/23; GPU-based, multi-density-formulation pilot + phased optimization |
-| 13 | "Archgen" (AutoDMP++) | **1.3479** | — | — | 0 | 2404s total | | New 4/24; multi-start + fast proxy screening + bounded refinement |
-| 14 | "Varun's Parallel Worlds" (GRPlace) | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: | |
-| 15 | "UT Austin" - AS (DREAMPlace Analytical) | **1.4076** | — | — | 0 | 17s/bench | | |
-| 16 | "ByteDancer" (Incremental CD) | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: | |
-| 17 | "TAISPlAce" (ALNS + Thompson Sampling) | **1.4321** | — | — | 0 | 28min/bench | | |
-| 18 | "Two-IIITK-Kids" (Proximal-Gradient Analytical) | **1.436** | — | — | 0 | 38min/bench | | New 5/2, resubmitted 5/4; PyTorch RePlAce-style + native C++ SA seed generation |
-| 19 | "Pragnay" (SweepingBellPlacement) | **1.4427** | — | — | 0 | 632s/bench | | Blocked on `compute_proxy_cost(..., plc=None)` in fallback path |
-| 20 | "No Man's Sky" (ALNS-MOS) | **1.4445** | — | — | 0 | 8.8min/bench | | New 5/4; Adaptive Large Neighborhood Search with multi-operator destroy/repair |
-| 21 | "another Waterloo kid" (Batched Nesterov GP) | **1.4568** | — | — | 0 | 118s/bench | | Blocked on Modal cloud dispatch — can't run air-gapped |
+| 1 | "vmallela" | **1.0109** | 0.7644 | 1.2921 | 0 | 15.5h total | :white_check_mark: | Verified 1.0109 (self-reported 1.1) |
+| 2 | "Cezar" | **1.037** | — | — | 0 | 55min/bench | | Resubmitted 5/3. Verification blocked on missing `steps/analytical.py` import. Previous variant verified 1.2224. |
+| 3 | "KLA MACH" | **1.2121** | 0.8527 | 1.6532 | 0 | 2h15min total | :white_check_mark: | Verified 1.2121 (self-reported 1.2355). Consolidates UTDA / Chuanqi Chen / KLA MACH submissions (one algorithm per team). |
+| 4 | "Hoop Dreams" | **1.2206** | — | — | 0 | 20min/bench | | New 5/1. Verification blocked on Python 3.12 / 3.11 ABI mismatch. |
+| 5 | "Shoom" | **1.2353** | — | — | 0 | 42min/bench | | Resubmitted 5/1 (was 1.3381). |
+| 6 | "ArzunPD" | **1.2478** | — | — | 0 | 55min/bench | | Resubmitted 5/1 (was HyperPlace, verified 1.4421). |
+| 7 | "RoRa" | **1.2788** | 0.9577 | 1.6222 | 0 | 2.6h total | :white_check_mark: | Verified 1.2788 (self-reported 1.2723). Resubmitted 5/1. |
+| 8 | "William Zhang" | **1.2767** | — | — | 0 | 259s/bench | | Resubmitted 5/2 (was "Convex Optimization", verified 1.4556). Blocked on missing `casadi` module. |
+| 9 | "MTK" | **1.2818** | 0.9073 | 1.6529 | 0 | 37s/bench (GPU) | :white_check_mark: | Verified 1.2818 (self-reported 1.317). |
+| 10 | "Electric Beatle" | **1.3253** | — | — | 0 | 2000s/bench (GPU) | | Resubmitted 4/30 (was verified 1.3913). |
+| 11 | "UToronto Analytical" | **1.3323** | 0.9371 | 1.6545 | 0 | 24min total | :white_check_mark: | Verified 1.3323 (self-reported 1.3325). |
+| 12 | "V5" | **1.3382** | — | — | 0 | 850s/bench | | New 4/23. |
+| 13 | "Archgen" | **1.3479** | — | — | 0 | 2404s total | | New 4/24. |
+| 14 | "Varun's Parallel Worlds" | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: | |
+| 15 | "UT Austin - AS" | **1.4076** | — | — | 0 | 17s/bench | | |
+| 16 | "ByteDancer" | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: | |
+| 17 | "TAISPlAce" | **1.4321** | — | — | 0 | 28min/bench | | |
+| 18 | "Two-IIITK-Kids" | **1.436** | — | — | 0 | 38min/bench | | New 5/2, resubmitted 5/4. |
+| 19 | "Pragnay" | **1.4427** | — | — | 0 | 632s/bench | | Blocked on `compute_proxy_cost(..., plc=None)` in fallback path. |
+| 20 | "No Man's Sky" | **1.4445** | — | — | 0 | 8.8min/bench | | New 5/4. Repo not accessible. |
+| 21 | "another Waterloo kid" | **1.4568** | — | — | 0 | 118s/bench | | Blocked on Modal cloud dispatch — can't run air-gapped. |
 | — | RePlAce (baseline) | **1.4578** | 0.9976 | 1.8370 | 0 | — | :white_check_mark: | |
-| 22 | "W3 Solutions" (GRACE) | **1.4824** | — | — | 0 | 90s/bench | | HybridPlacer runtime exceeds 1h/bench cap on our hardware |
-| 23 | "Jiangban Ya" (Spectral-Seed + Adaptive Legalizer) | **1.4943** | 1.0891 | 1.8099 | 0 | 49s/bench | :white_check_mark: | |
-| 24 | "UTAUSTIN-CT" (PLC-Exact Congestion-Aware SA) | **1.5062** | 1.1363 | 1.7941 | 0 | 6s/bench | :white_check_mark: | |
-| 25 | "oracleX" (Oracle) | **1.5130** | 1.1340 | 1.7937 | 0 | 11s/bench | :white_check_mark: | |
-| 26 | "SEVmakers" (Hybrid Legalization + SA) | **1.5200** | — | — | 0 | 200s/bench | | Private repo — pending judge access |
-| 27 | "CA" (congestion_aware) | **1.5247** | 1.2226 | 1.7945 | 0 | 2s/bench | :white_check_mark: | Verified 1.5247 vs self-reported 1.5238 |
-| 28 | "#5 ubc cpen student" (Gene Pool Shuffle) | **1.5337** | 1.1411 | 1.8084 | 0 | 13s/bench | :white_check_mark: | |
+| 22 | "W3 Solutions" | **1.4824** | — | — | 0 | 90s/bench | | Runtime exceeds 1h/bench cap. |
+| 23 | "Jiangban Ya" | **1.4943** | 1.0891 | 1.8099 | 0 | 49s/bench | :white_check_mark: | |
+| 24 | "UTAUSTIN-CT" | **1.5062** | 1.1363 | 1.7941 | 0 | 6s/bench | :white_check_mark: | |
+| 25 | "oracleX" | **1.5130** | 1.1340 | 1.7937 | 0 | 11s/bench | :white_check_mark: | |
+| 26 | "SEVmakers" | **1.5200** | — | — | 0 | 200s/bench | | Private repo — pending judge access. |
+| 27 | "CA" | **1.5247** | 1.2226 | 1.7945 | 0 | 2s/bench | :white_check_mark: | Verified 1.5247 (self-reported 1.5238). |
+| 28 | "#5 ubc cpen student" | **1.5337** | 1.1411 | 1.8084 | 0 | 13s/bench | :white_check_mark: | |
 | 29 | Will Seed (Partcl) | **1.5338** | 1.1625 | 1.7965 | 0 | 35s total | :white_check_mark: | |
-| 30 | "RUDY Can't Fail" (Fast Proxy CD) | **1.5397** | 1.1927 | 1.8881 | 0 | 6min total | :white_check_mark: | Verified 1.5397 (self-reported 1.3605 — 13% worse than self-report); 0 overlaps but below RePlAce baseline |
-| 31 | "UT Austin" - RH (DREAMPlace) | **1.6037** | — | — | 0 | 4.5s/bench | | |
-| 32 | "UT Austin" - CT (PROXYCost) | **1.8706** | — | — | 0 | 187s/bench | | |
-| 33 | "AS" (Shelf Stacker) | **1.9121** | 1.4614 | 2.3508 | 0 | 0.16s total | :white_check_mark: | |
-| 34 | "Adi's Team" (GNN-ePlace Hybrid) | **2.0025** | — | — | 0 | 3726s/bench | | Blocked on `compute_proxy_cost(skip_congestion=True)` kwarg |
-| 35 | "Sharc #1" (Auction Placer) | **2.0433** | 1.5143 | 2.4336 | 0 | 96s/bench | :white_check_mark: | |
+| 30 | "RUDY Can't Fail" | **1.5397** | 1.1927 | 1.8881 | 0 | 6min total | :white_check_mark: | Verified 1.5397 (self-reported 1.3605). |
+| 31 | "UT Austin - RH" | **1.6037** | — | — | 0 | 4.5s/bench | | |
+| 32 | "UT Austin - CT" | **1.8706** | — | — | 0 | 187s/bench | | |
+| 33 | "AS" | **1.9121** | 1.4614 | 2.3508 | 0 | 0.16s total | :white_check_mark: | |
+| 34 | "Adi's Team" | **2.0025** | — | — | 0 | 3726s/bench | | Blocked on `compute_proxy_cost(skip_congestion=True)` kwarg. |
+| 35 | "Sharc #1" | **2.0433** | 1.5143 | 2.4336 | 0 | 96s/bench | :white_check_mark: | |
 | — | SA (baseline) | 2.1251 | 1.3166 | 3.6726 | 0 | — | :white_check_mark: | |
 | — | Greedy Row (demo) | 2.2109 | 1.6728 | 2.7696 | 0 | 0.3s total | :white_check_mark: | |
-| — | "Binghamton" (feng shui) | pending | — | — | — | — | | |
-| — | "MacroBio" (Two-Opt Swap) | pending | — | — | — | — | | |
-| DQ | "Mike Gao" (autoresearch) | self-reported 1.3255 | — | — | 1939 | 16min/bench | | DREAMPlace silently fails in eval environment, returns unlegalized placements (47–189 overlaps per benchmark) |
-| DQ | "BakaBobo" (Global Relocation Sweep) | self-reported 1.4044 | — | — | — | 282s/bench | | Imports `macro_place.fast_proxy` which isn't bundled and isn't part of the evaluator — code won't run |
+| — | "Binghamton" | pending | — | — | — | — | | |
+| — | "MacroBio" | pending | — | — | — | — | | |
+| DQ | "Mike Gao" | self-reported 1.3255 | — | — | 1939 | 16min/bench | | 1939 overlaps across 17 benchmarks. |
+| DQ | "BakaBobo" | self-reported 1.4044 | — | — | — | 282s/bench | | Missing import — code won't run. |
 
 *Submit your results via the [Submission Link](https://forms.gle/YDRtYV5Vq68SZgKW9)!*
 


### PR DESCRIPTION
Cherry-picks the de-spoiling commit from PR #85 that didn't land on main. Removes algorithm-specific phrasing (Hessian saddle, DREAMPlace, Optuna, Adam, ALNS, coordinate descent, etc.) from team names and Notes column. Notes now contain only operational facts: verified vs self-reported scores, resubmit dates, blocker descriptions.

Competition is open until 5/21 — keeping the leaderboard public but not letting it spoil techniques for the teams that innovated them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)