### PR TITLE
Verify Hoop Dreams (1.2207, #4) — first team-provided Dockerfile path

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ For full Grand Prize scoring rules, feasibility gate, tie-breaking, and ORFS-fai
 - All submissions must be registered via this [Submission Link](https://forms.gle/YDRtYV5Vq68SZgKW9).
 - All submissions must be under 1 hour end-to-end runtime (per benchmark) for the macro placement algorithm.
 - All submissions will be evaluated on a AMD EPYC 9655P with 16 cores + 100GB of memory and an NVIDIA RTX 6000 Ada 48GB.
+- Submissions may include a `Dockerfile` to define their own runtime environment. If present, the judges will build the image and run the eval against it (with `--network none` enforced at run time, so any `pip install` / `apt-get install` steps must happen at build time). Otherwise, the submission's `placer.py` is mounted into the judges' standard image (`pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime`, Python 3.11).
 
 ## Additional Rules
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 | 1 | "vmallela" | **1.0109** | 0.7644 | 1.2921 | 0 | 15.5h total | :white_check_mark: | Verified 1.0109 (self-reported 1.1) |
 | 2 | "Cezar" | **1.037** | — | — | 0 | 55min/bench | | Resubmitted 5/3. Verification blocked on missing `steps/analytical.py` import. Previous variant verified 1.2224. |
 | 3 | "KLA MACH" | **1.2121** | 0.8527 | 1.6532 | 0 | 2h15min total | :white_check_mark: | Verified 1.2121 (self-reported 1.2355). Consolidates UTDA / Chuanqi Chen / KLA MACH submissions (one algorithm per team). |
-| 4 | "Hoop Dreams" | **1.2206** | — | — | 0 | 20min/bench | | New 5/1. Verification blocked on Python 3.12 / 3.11 ABI mismatch. |
+| 4 | "Hoop Dreams" | **1.2207** | 0.8972 | 1.5072 | 0 | 5h total | :white_check_mark: | Verified 1.2207 (self-reported 1.2206). Built and ran from team-provided `Dockerfile`. |
 | 5 | "Shoom" | **1.2353** | — | — | 0 | 42min/bench | | Resubmitted 5/1 (was 1.3381). |
 | 6 | "ArzunPD" | **1.2478** | — | — | 0 | 55min/bench | | Resubmitted 5/1 (was HyperPlace, verified 1.4421). |
 | 7 | "RoRa" | **1.2788** | 0.9577 | 1.6222 | 0 | 2.6h total | :white_check_mark: | Verified 1.2788 (self-reported 1.2723). Resubmitted 5/1. |


### PR DESCRIPTION
Verified avg proxy 1.2207 across all 17 IBM benchmarks, 0 overlaps, ~5h total runtime. Self-reported 1.2206 — verified essentially exact match (0.0001 off).

Built from the team's `submissions/dreamtuna/Dockerfile` (Ubuntu 24.04 + Python 3.12 + bundled DREAMPlace .so files compiled for cpython-312) and ran air-gapped (`docker run --network none`). First submission verified via team-provided Dockerfile.

Stays at rank 4 (between KLA MACH 1.2121 and Shoom 1.2353 self-reported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)