### PR TITLE
Leaderboard 5/11: Cezar v3 verified, +9 new entries, 4 resubmit updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,44 +232,53 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 | Rank | Team | Avg Proxy Cost | Best | Worst | Overlaps | Runtime | Verified | Notes |
 |------|------|---------------|------|-------|----------|---------|----------|-------|
 | 1 | "vmallela" | **1.0109** | 0.7644 | 1.2921 | 0 | 15.5h total | :white_check_mark: | Verified 1.0109 (self-reported 1.1) |
-| 2 | "Cezar" | **1.037** | — | — | 0 | 55min/bench | | Resubmitted 5/3. Verification blocked on missing `steps/analytical.py` import. Previous variant verified 1.2224. |
-| 3 | "KLA MACH" | **1.2121** | 0.8527 | 1.6532 | 0 | 2h15min total | :white_check_mark: | Verified 1.2121 (self-reported 1.2355). Consolidates UTDA / Chuanqi Chen / KLA MACH submissions (one algorithm per team). |
-| 4 | "Hoop Dreams" | **1.2207** | 0.8972 | 1.5072 | 0 | 5h total | :white_check_mark: | Verified 1.2207 (self-reported 1.2206). Built and ran from team-provided `Dockerfile`. |
-| 5 | "Shoom" | **1.2353** | — | — | 0 | 42min/bench | | Resubmitted 5/1 (was 1.3381). |
-| 6 | "ArzunPD" | **1.2478** | — | — | 0 | 55min/bench | | Resubmitted 5/1 (was HyperPlace, verified 1.4421). |
-| 7 | "RoRa" | **1.2788** | 0.9577 | 1.6222 | 0 | 2.6h total | :white_check_mark: | Verified 1.2788 (self-reported 1.2723). Resubmitted 5/1. |
-| 8 | "William Zhang" | **1.2767** | — | — | 0 | 259s/bench | | Resubmitted 5/2 (was "Convex Optimization", verified 1.4556). Blocked on missing `casadi` module. |
-| 9 | "MTK" | **1.2818** | 0.9073 | 1.6529 | 0 | 37s/bench (GPU) | :white_check_mark: | Verified 1.2818 (self-reported 1.317). |
-| 10 | "Electric Beatle" | **1.3253** | — | — | 0 | 2000s/bench (GPU) | | Resubmitted 4/30 (was verified 1.3913). |
-| 11 | "UToronto Analytical" | **1.3323** | 0.9371 | 1.6545 | 0 | 24min total | :white_check_mark: | Verified 1.3323 (self-reported 1.3325). |
-| 12 | "V5" | **1.3382** | — | — | 0 | 850s/bench | | New 4/23. |
-| 13 | "Archgen" | **1.3479** | — | — | 0 | 2404s total | | New 4/24. |
-| 14 | "Varun's Parallel Worlds" | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: | |
-| 15 | "UT Austin - AS" | **1.4076** | — | — | 0 | 17s/bench | | |
-| 16 | "ByteDancer" | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: | |
-| 17 | "TAISPlAce" | **1.4321** | — | — | 0 | 28min/bench | | |
-| 18 | "Two-IIITK-Kids" | **1.436** | — | — | 0 | 38min/bench | | New 5/2, resubmitted 5/4. |
-| 19 | "Pragnay" | **1.4427** | — | — | 0 | 632s/bench | | Blocked on `compute_proxy_cost(..., plc=None)` in fallback path. |
-| 20 | "No Man's Sky" | **1.4445** | — | — | 0 | 8.8min/bench | | New 5/4. Repo not accessible. |
-| 21 | "another Waterloo kid" | **1.4568** | — | — | 0 | 118s/bench | | Blocked on Modal cloud dispatch — can't run air-gapped. |
+| 2 | "DREAMPlaceProMaxUltra" | **1.0467** | — | — | 0 | 629s/bench | | New 5/10. |
+| 3 | "Vibe" | **1.1477** | — | — | 0 | 13851s total | | New 5/7. |
+| 4 | "Archgen" | **1.16511** | — | — | 0 | 3343s/bench | | Resubmitted 5/9 (was 1.3479). |
+| 5 | "ArzunPD" | **1.1883** | — | — | 0 | 55min/bench | | Resubmitted 5/8 (was 1.2478). |
+| 6 | "Cezar" | **1.1893** | 0.9041 | 1.4379 | 0 | 15.5h total | :white_check_mark: | Verified 1.1893 (self-reported 1.037). Resubmitted 5/3. Previous variant verified 1.2224. |
+| 7 | "Talyxion" | **1.2075** | — | — | 0 | 7.2min/bench | | New 5/10. |
+| 8 | "KLA MACH" | **1.2121** | 0.8527 | 1.6532 | 0 | 2h15min total | :white_check_mark: | Verified 1.2121 (self-reported 1.2355). Consolidates UTDA / Chuanqi Chen / KLA MACH submissions (one algorithm per team). |
+| 9 | "Hoop Dreams" | **1.2207** | 0.8972 | 1.5072 | 0 | 5h total | :white_check_mark: | Verified 1.2207 (self-reported 1.2206). Built and ran from team-provided `Dockerfile`. |
+| 10 | "Shoom" | **1.2353** | — | — | 0 | 42min/bench | | Resubmitted 5/1 (was 1.3381). |
+| 11 | "Adam_A" | **1.2655** | — | — | 0 | 682s/bench | | New 5/10. |
+| 12 | "William Zhang" | **1.2767** | — | — | 0 | 259s/bench | | Resubmitted 5/2 (was "Convex Optimization", verified 1.4556). Blocked on missing `casadi` module. |
+| 13 | "RoRa" | **1.2788** | 0.9577 | 1.6222 | 0 | 2.6h total | :white_check_mark: | Verified 1.2788 (self-reported 1.2723). Resubmitted 5/1. |
+| 14 | "MTK" | **1.2818** | 0.9073 | 1.6529 | 0 | 37s/bench (GPU) | :white_check_mark: | Verified 1.2818 (self-reported 1.317). |
+| 15 | "Electric Beatle" | **1.3253** | — | — | 0 | 2000s/bench (GPU) | | Resubmitted 4/30 (was verified 1.3913). |
+| 16 | "UToronto Analytical" | **1.3323** | 0.9371 | 1.6545 | 0 | 24min total | :white_check_mark: | Verified 1.3323 (self-reported 1.3325). |
+| 17 | "V5" | **1.3382** | — | — | 0 | 850s/bench | | New 4/23. |
+| 18 | "jrslbenn" | **1.353** | — | — | 0 | 750s/bench | | New 5/4. |
+| 19 | "Barsat Khadka" | **1.38** | — | — | 0 | 1000-1800s/bench | | New 5/5. |
+| 20 | "Varun's Parallel Worlds" | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: | |
+| 21 | "UT Austin - AS" | **1.4076** | — | — | 0 | 17s/bench | | |
+| 22 | "ByteDancer" | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: | |
+| 23 | "TAISPlAce" | **1.4321** | — | — | 0 | 28min/bench | | |
+| 24 | "Two-IIITK-Kids" | **1.436** | — | — | 0 | 38min/bench | | New 5/2, resubmitted 5/4. |
+| 25 | "Pragnay" | **1.4427** | — | — | 0 | 632s/bench | | Blocked on `compute_proxy_cost(..., plc=None)` in fallback path. |
+| 26 | "No Man's Sky" | **1.4445** | — | — | 0 | 8.8min/bench | | New 5/4, resubmitted 5/6. |
+| 27 | "Aegir" | **1.4553** | — | — | 0 | 104s/bench | | New 5/9. |
+| 28 | "another Waterloo kid" | **1.4568** | — | — | 0 | 118s/bench | | Blocked on Modal cloud dispatch — can't run air-gapped. |
 | — | RePlAce (baseline) | **1.4578** | 0.9976 | 1.8370 | 0 | — | :white_check_mark: | |
-| 22 | "W3 Solutions" | **1.4824** | — | — | 0 | 90s/bench | | Runtime exceeds 1h/bench cap. |
-| 23 | "Jiangban Ya" | **1.4943** | 1.0891 | 1.8099 | 0 | 49s/bench | :white_check_mark: | |
-| 24 | "UTAUSTIN-CT" | **1.5062** | 1.1363 | 1.7941 | 0 | 6s/bench | :white_check_mark: | |
-| 25 | "oracleX" | **1.5130** | 1.1340 | 1.7937 | 0 | 11s/bench | :white_check_mark: | |
-| 26 | "SEVmakers" | **1.5200** | — | — | 0 | 200s/bench | | Private repo — pending judge access. |
-| 27 | "CA" | **1.5247** | 1.2226 | 1.7945 | 0 | 2s/bench | :white_check_mark: | Verified 1.5247 (self-reported 1.5238). |
-| 28 | "#5 ubc cpen student" | **1.5337** | 1.1411 | 1.8084 | 0 | 13s/bench | :white_check_mark: | |
-| 29 | Will Seed (Partcl) | **1.5338** | 1.1625 | 1.7965 | 0 | 35s total | :white_check_mark: | |
-| 30 | "RUDY Can't Fail" | **1.5397** | 1.1927 | 1.8881 | 0 | 6min total | :white_check_mark: | Verified 1.5397 (self-reported 1.3605). |
-| 31 | "UT Austin - RH" | **1.6037** | — | — | 0 | 4.5s/bench | | |
-| 32 | "UT Austin - CT" | **1.8706** | — | — | 0 | 187s/bench | | |
-| 33 | "AS" | **1.9121** | 1.4614 | 2.3508 | 0 | 0.16s total | :white_check_mark: | |
-| 34 | "Adi's Team" | **2.0025** | — | — | 0 | 3726s/bench | | Blocked on `compute_proxy_cost(skip_congestion=True)` kwarg. |
-| 35 | "Sharc #1" | **2.0433** | 1.5143 | 2.4336 | 0 | 96s/bench | :white_check_mark: | |
+| 29 | "W3 Solutions" | **1.4824** | — | — | 0 | 90s/bench | | Runtime exceeds 1h/bench cap. |
+| 30 | "Jiangban Ya" | **1.4943** | 1.0891 | 1.8099 | 0 | 49s/bench | :white_check_mark: | |
+| 31 | "UTAUSTIN-CT" | **1.5062** | 1.1363 | 1.7941 | 0 | 6s/bench | :white_check_mark: | |
+| 32 | "oracleX" | **1.5130** | 1.1340 | 1.7937 | 0 | 11s/bench | :white_check_mark: | |
+| 33 | "SEVmakers" | **1.5200** | — | — | 0 | 200s/bench | | Private repo — pending judge access. |
+| 34 | "CA" | **1.5247** | 1.2226 | 1.7945 | 0 | 2s/bench | :white_check_mark: | Verified 1.5247 (self-reported 1.5238). |
+| 35 | "ZeroLatency" | **1.5286** | — | — | 0 | 17s total | | New 5/9. |
+| 36 | "#5 ubc cpen student" | **1.5337** | 1.1411 | 1.8084 | 0 | 13s/bench | :white_check_mark: | |
+| 37 | Will Seed (Partcl) | **1.5338** | 1.1625 | 1.7965 | 0 | 35s total | :white_check_mark: | |
+| 38 | "RUDY Can't Fail" | **1.5397** | 1.1927 | 1.8881 | 0 | 6min total | :white_check_mark: | Verified 1.5397 (self-reported 1.3605). |
+| 39 | "UT Austin - RH" | **1.6037** | — | — | 0 | 4.5s/bench | | |
+| 40 | "Binghamton" | **1.7621** | — | — | 0 | 2min/bench | | New 5/10. |
+| 41 | "UT Austin - CT" | **1.8706** | — | — | 0 | 187s/bench | | |
+| 42 | "rpocevi" | **1.8894** | — | — | 0 | 22.5s/bench | | New 5/9. |
+| 43 | "AS" | **1.9121** | 1.4614 | 2.3508 | 0 | 0.16s total | :white_check_mark: | |
+| 44 | "Adi's Team" | **2.0025** | — | — | 0 | 3726s/bench | | Blocked on `compute_proxy_cost(skip_congestion=True)` kwarg. |
+| 45 | "Sharc #1" | **2.0433** | 1.5143 | 2.4336 | 0 | 96s/bench | :white_check_mark: | |
 | — | SA (baseline) | 2.1251 | 1.3166 | 3.6726 | 0 | — | :white_check_mark: | |
 | — | Greedy Row (demo) | 2.2109 | 1.6728 | 2.7696 | 0 | 0.3s total | :white_check_mark: | |
-| — | "Binghamton" | pending | — | — | — | — | | |
 | — | "MacroBio" | pending | — | — | — | — | | |
 | DQ | "Mike Gao" | self-reported 1.3255 | — | — | 1939 | 16min/bench | | 1939 overlaps across 17 benchmarks. |
 | DQ | "BakaBobo" | self-reported 1.4044 | — | — | — | 282s/bench | | Missing import — code won't run. |


### PR DESCRIPTION
## Summary

**Verifications (subsumes PR #90):**
- **Cezar v3** — verified **1.1893** (self-reported 1.037), takes #6.

**Resubmit value updates** (latest score per team):
- **Archgen** — 1.3479 → **1.16511** (AutoDMP + GPU, 5/9). Now #4.
- **ArzunPD** — 1.2478 → **1.1883** (Hyperplace, 5/8). Now #5.
- **Binghamton** — pending → **1.7621** (feng shui, 5/10). Now #40.

**New entries:**
| Team | Score | Rank |
|---|---|---|
| DREAMPlaceProMaxUltra | 1.0467 | #2 |
| Vibe | 1.1477 | #3 |
| Talyxion | 1.2075 | #7 |
| Adam_A | 1.2655 | #11 |
| jrslbenn (SPIRAL) | 1.353 | #18 |
| Barsat Khadka (fmpa) | 1.38 | #19 |
| Aegir | 1.4553 | #27 |
| ZeroLatency | 1.5286 | #35 |
| rpocevi | 1.8894 | #42 |

## Top 10 after this PR

| Rank | Team | Score | Verified |
|---|---|---|---|
| 1 | vmallela | 1.0109 | ✅ |
| 2 | DREAMPlaceProMaxUltra | 1.0467 | |
| 3 | Vibe | 1.1477 | |
| 4 | Archgen | 1.16511 | |
| 5 | ArzunPD | 1.1883 | |
| 6 | Cezar | 1.1893 | ✅ |
| 7 | Talyxion | 1.2075 | |
| 8 | KLA MACH | 1.2121 | ✅ |
| 9 | Hoop Dreams | 1.2207 | ✅ |
| 10 | Shoom | 1.2353 | |

Closes PR #90 (subsumed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)