### PR TITLE
Leaderboard update: 5/13 + 5/15 entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,46 +240,49 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 | 7 | "Vibe" | **1.1477** | — | — | 0 | 13851s total | | New 5/7. |
 | 8 | "JonaU" | **1.1524** | — | — | 0 | 55min/bench | | New 5/13. SoftSwap (coord descent + adaptive push-apart). |
 | 9 | "Archgen" | **1.16511** | — | — | 0 | 3343s/bench | | Resubmitted 5/9 (was 1.3479). |
-| 10 | "ArzunPD" | **1.1883** | — | — | 0 | 55min/bench | | Resubmitted 5/8 (was 1.2478). |
-| 11 | "Talyxion" | **1.2075** | — | — | 0 | 7.2min/bench | | New 5/10. |
-| 12 | "KLA MACH" | **1.2121** | 0.8527 | 1.6532 | 0 | 2h15min total | :white_check_mark: | Verified 1.2121 (self-reported 1.2355). Consolidates UTDA / Chuanqi Chen / KLA MACH submissions (one algorithm per team). |
+| 10 | "KLA MACH" | **1.1764** | — | — | 0 | 15min/bench | | Resubmitted 5/14 as "ProxyCD" (DREAMPlace + parallel CD/SA + ILS). Previous algorithm verified 1.2121 (self-reported 1.2355). Consolidates UTDA / Chuanqi Chen / KLA MACH submissions (one algo per team). |
+| 11 | "ArzunPD" | **1.1883** | — | — | 0 | 55min/bench | | Resubmitted 5/8 (was 1.2478). |
+| 12 | "Talyxion" | **1.2075** | — | — | 0 | 7.2min/bench | | New 5/10. |
 | 13 | "Hoop Dreams" | **1.2207** | 0.8972 | 1.5072 | 0 | 5h total | :white_check_mark: | Verified 1.2207 (self-reported 1.2206). Built and ran from team-provided `Dockerfile`. |
-| 14 | "Adam_A" | **1.2655** | — | — | 0 | 682s/bench | | New 5/10. |
-| 15 | "The Basin Jumpers" | **1.2748** | — | — | 0 | 900s/bench | | Resubmitted 5/13 by William Zhang + Leon Do (was "William Zhang" / "Convex Optimization", verified 1.4556; prior self-report 1.2767 was blocked on missing `casadi` module). |
-| 16 | "RoRa" | **1.2788** | 0.9577 | 1.6222 | 0 | 2.6h total | :white_check_mark: | Verified 1.2788 (self-reported 1.2723). Resubmitted 5/1. |
-| 17 | "MTK" | **1.2818** | 0.9073 | 1.6529 | 0 | 37s/bench (GPU) | :white_check_mark: | Verified 1.2818 (self-reported 1.317). |
-| 18 | "Electric Beatle" | **1.3253** | — | — | 0 | 2000s/bench (GPU) | | Resubmitted 4/30 (was verified 1.3913). |
-| 19 | "UToronto Analytical" | **1.3323** | 0.9371 | 1.6545 | 0 | 24min total | :white_check_mark: | Verified 1.3323 (self-reported 1.3325). |
-| 20 | "V5" | **1.3382** | — | — | 0 | 850s/bench | | New 4/23. |
-| 21 | "jrslbenn" | **1.353** | — | — | 0 | 750s/bench | | New 5/4. |
-| 22 | "Barsat Khadka" | **1.38** | — | — | 0 | 1000-1800s/bench | | New 5/5. |
-| 23 | "Varun's Parallel Worlds" | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: | |
-| 24 | "UT Austin - AS" | **1.4076** | — | — | 0 | 17s/bench | | |
-| 25 | "ByteDancer" | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: | |
-| 26 | "TAISPlAce" | **1.4321** | — | — | 0 | 28min/bench | | |
-| 27 | "Two-IIITK-Kids" | **1.436** | — | — | 0 | 38min/bench | | New 5/2, resubmitted 5/4. |
-| 28 | "Pragnay" | **1.4427** | — | — | 0 | 632s/bench | | Blocked on `compute_proxy_cost(..., plc=None)` in fallback path. |
-| 29 | "No Man's Sky" | **1.4445** | — | — | 0 | 8.8min/bench | | New 5/4, resubmitted 5/6. |
-| 30 | "Aegir" | **1.4553** | — | — | 0 | 104s/bench | | New 5/9. |
-| 31 | "another Waterloo kid" | **1.4568** | — | — | 0 | 118s/bench | | Blocked on Modal cloud dispatch — can't run air-gapped. |
+| 14 | "KKPlace" | **1.2451** | — | — | 0 | 55min/bench | | New 5/13. Congestion-driven RelPlace. |
+| 15 | "MakerCode" | **1.26** | — | — | 0 | 55min/bench | | New 5/15. CD + LNS (Wei Yet Ng). |
+| 16 | "Adam_A" | **1.2655** | — | — | 0 | 682s/bench | | New 5/10. |
+| 17 | "The Basin Jumpers" | **1.2748** | — | — | 0 | 900s/bench | | Resubmitted 5/13 by William Zhang + Leon Do (was "William Zhang" / "Convex Optimization", verified 1.4556; prior self-report 1.2767 was blocked on missing `casadi` module). |
+| 18 | "RoRa" | **1.2788** | 0.9577 | 1.6222 | 0 | 2.6h total | :white_check_mark: | Verified 1.2788 (self-reported 1.2723). Resubmitted 5/1. |
+| 19 | "MTK" | **1.2818** | 0.9073 | 1.6529 | 0 | 37s/bench (GPU) | :white_check_mark: | Verified 1.2818 (self-reported 1.317). |
+| 20 | "Two-IIITK-Kids" | **1.2868** | — | — | 0 | 19.4min/bench | | Resubmitted 5/13 as "SmoothSA" (Adam-optimized soft proxy + parallel C++ SA polish). Was 1.436. |
+| 21 | "Electric Beatle" | **1.3253** | — | — | 0 | 2000s/bench (GPU) | | Resubmitted 4/30 (was verified 1.3913). |
+| 22 | "UToronto Analytical" | **1.3323** | 0.9371 | 1.6545 | 0 | 24min total | :white_check_mark: | Verified 1.3323 (self-reported 1.3325). |
+| 23 | "V5" | **1.3382** | — | — | 0 | 850s/bench | | New 4/23. |
+| 24 | "jrslbenn" | **1.353** | — | — | 0 | 750s/bench | | New 5/4. |
+| 25 | "Barsat Khadka" | **1.38** | — | — | 0 | 1000-1800s/bench | | New 5/5. |
+| 26 | "Varun's Parallel Worlds" | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: | |
+| 27 | "UT Austin - AS" | **1.4076** | — | — | 0 | 17s/bench | | |
+| 28 | "ByteDancer" | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: | |
+| 29 | "TAISPlAce" | **1.4321** | — | — | 0 | 28min/bench | | |
+| 30 | "Pragnay" | **1.4427** | — | — | 0 | 632s/bench | | Blocked on `compute_proxy_cost(..., plc=None)` in fallback path. |
+| 31 | "No Man's Sky" | **1.4445** | — | — | 0 | 8.8min/bench | | New 5/4, resubmitted 5/6. |
+| 32 | "Aegir" | **1.4553** | — | — | 0 | 104s/bench | | New 5/9. |
+| 33 | "another Waterloo kid" | **1.4568** | — | — | 0 | 118s/bench | | Blocked on Modal cloud dispatch — can't run air-gapped. |
 | — | RePlAce (baseline) | **1.4578** | 0.9976 | 1.8370 | 0 | — | :white_check_mark: | |
-| 32 | "W3 Solutions" | **1.4824** | — | — | 0 | 90s/bench | | Runtime exceeds 1h/bench cap. |
-| 33 | "Jiangban Ya" | **1.4943** | 1.0891 | 1.8099 | 0 | 49s/bench | :white_check_mark: | |
-| 34 | "UTAUSTIN-CT" | **1.5062** | 1.1363 | 1.7941 | 0 | 6s/bench | :white_check_mark: | |
-| 35 | "oracleX" | **1.5130** | 1.1340 | 1.7937 | 0 | 11s/bench | :white_check_mark: | |
-| 36 | "SEVmakers" | **1.5200** | — | — | 0 | 200s/bench | | Private repo — pending judge access. |
-| 37 | "CA" | **1.5247** | 1.2226 | 1.7945 | 0 | 2s/bench | :white_check_mark: | Verified 1.5247 (self-reported 1.5238). |
-| 38 | "ZeroLatency" | **1.5286** | — | — | 0 | 17s total | | New 5/9. |
-| 39 | "#5 ubc cpen student" | **1.5337** | 1.1411 | 1.8084 | 0 | 13s/bench | :white_check_mark: | |
-| 40 | Will Seed (Partcl) | **1.5338** | 1.1625 | 1.7965 | 0 | 35s total | :white_check_mark: | |
-| 41 | "RUDY Can't Fail" | **1.5397** | 1.1927 | 1.8881 | 0 | 6min total | :white_check_mark: | Verified 1.5397 (self-reported 1.3605). |
-| 42 | "UT Austin - RH" | **1.6037** | — | — | 0 | 4.5s/bench | | |
-| 43 | "Binghamton" | **1.7621** | — | — | 0 | 2min/bench | | New 5/10. Team also reports 1.5375 from feeding feng-shui fixed-macro locations to DREAMPlace for soft macros (not legalized). |
-| 44 | "UT Austin - CT" | **1.8706** | — | — | 0 | 187s/bench | | |
-| 45 | "rpocevi" | **1.8894** | — | — | 0 | 22.5s/bench | | New 5/9. |
-| 46 | "AS" | **1.9121** | 1.4614 | 2.3508 | 0 | 0.16s total | :white_check_mark: | |
-| 47 | "Adi's Team" | **2.0025** | — | — | 0 | 3726s/bench | | Blocked on `compute_proxy_cost(skip_congestion=True)` kwarg. |
-| 48 | "Sharc #1" | **2.0433** | 1.5143 | 2.4336 | 0 | 96s/bench | :white_check_mark: | |
+| 34 | "W3 Solutions" | **1.4824** | — | — | 0 | 90s/bench | | Runtime exceeds 1h/bench cap. |
+| 35 | "Captain.Rhinoceros" | **1.4906** | — | — | 0 | <26.6min/bench | | New 5/13. Deterministic constructive placer (connectivity-aware targets + bounded local refinement). |
+| 36 | "Jiangban Ya" | **1.4943** | 1.0891 | 1.8099 | 0 | 49s/bench | :white_check_mark: | |
+| 37 | "UTAUSTIN-CT" | **1.5062** | 1.1363 | 1.7941 | 0 | 6s/bench | :white_check_mark: | |
+| 38 | "oracleX" | **1.5130** | 1.1340 | 1.7937 | 0 | 11s/bench | :white_check_mark: | |
+| 39 | "SEVmakers" | **1.5200** | — | — | 0 | 200s/bench | | Private repo — pending judge access. |
+| 40 | "CA" | **1.5247** | 1.2226 | 1.7945 | 0 | 2s/bench | :white_check_mark: | Verified 1.5247 (self-reported 1.5238). |
+| 41 | "ZeroLatency" | **1.5286** | — | — | 0 | 17s total | | New 5/9. |
+| 42 | "#5 ubc cpen student" | **1.5337** | 1.1411 | 1.8084 | 0 | 13s/bench | :white_check_mark: | |
+| 43 | Will Seed (Partcl) | **1.5338** | 1.1625 | 1.7965 | 0 | 35s total | :white_check_mark: | |
+| 44 | "RUDY Can't Fail" | **1.5397** | 1.1927 | 1.8881 | 0 | 6min total | :white_check_mark: | Verified 1.5397 (self-reported 1.3605). |
+| 45 | "UT Austin - RH" | **1.6037** | — | — | 0 | 4.5s/bench | | |
+| 46 | "Binghamton" | **1.7621** | — | — | 0 | 2min/bench | | New 5/10. Team also reports 1.5375 from feeding feng-shui fixed-macro locations to DREAMPlace for soft macros (not legalized). |
+| 47 | "UT Austin - CT" | **1.8706** | — | — | 0 | 187s/bench | | |
+| 48 | "rpocevi" | **1.8894** | — | — | 0 | 22.5s/bench | | New 5/9. |
+| 49 | "AS" | **1.9121** | 1.4614 | 2.3508 | 0 | 0.16s total | :white_check_mark: | |
+| 50 | "Adi's Team" | **2.0025** | — | — | 0 | 3726s/bench | | Blocked on `compute_proxy_cost(skip_congestion=True)` kwarg. |
+| 51 | "Sharc #1" | **2.0433** | 1.5143 | 2.4336 | 0 | 96s/bench | :white_check_mark: | |
 | — | SA (baseline) | 2.1251 | 1.3166 | 3.6726 | 0 | — | :white_check_mark: | |
 | — | Greedy Row (demo) | 2.2109 | 1.6728 | 2.7696 | 0 | 0.3s total | :white_check_mark: | |
 | — | "MacroBio" | pending | — | — | — | — | | |

--- a/README.md
+++ b/README.md
@@ -231,52 +231,55 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 
 | Rank | Team | Avg Proxy Cost | Best | Worst | Overlaps | Runtime | Verified | Notes |
 |------|------|---------------|------|-------|----------|---------|----------|-------|
-| 1 | "vmallela" | **1.0109** | 0.7644 | 1.2921 | 0 | 15.5h total | :white_check_mark: | Verified 1.0109 (self-reported 1.1) |
-| 2 | "DREAMPlaceProMaxUltra" | **1.0121** | 0.7955 | 1.2167 | 0 | 6h total | :white_check_mark: | Verified 1.0121 (self-reported 1.0467). Built and ran from team-provided `Dockerfile`. |
-| 3 | "Vibe" | **1.1477** | — | — | 0 | 13851s total | | New 5/7. |
-| 4 | "Archgen" | **1.16511** | — | — | 0 | 3343s/bench | | Resubmitted 5/9 (was 1.3479). |
-| 5 | "ArzunPD" | **1.1883** | — | — | 0 | 55min/bench | | Resubmitted 5/8 (was 1.2478). |
-| 6 | "Cezar" | **1.1893** | 0.9041 | 1.4379 | 0 | 15.5h total | :white_check_mark: | Verified 1.1893 (self-reported 1.037). Resubmitted 5/3. Previous variant verified 1.2224. |
-| 7 | "Talyxion" | **1.2075** | — | — | 0 | 7.2min/bench | | New 5/10. |
-| 8 | "KLA MACH" | **1.2121** | 0.8527 | 1.6532 | 0 | 2h15min total | :white_check_mark: | Verified 1.2121 (self-reported 1.2355). Consolidates UTDA / Chuanqi Chen / KLA MACH submissions (one algorithm per team). |
-| 9 | "Hoop Dreams" | **1.2207** | 0.8972 | 1.5072 | 0 | 5h total | :white_check_mark: | Verified 1.2207 (self-reported 1.2206). Built and ran from team-provided `Dockerfile`. |
-| 10 | "Adam_A" | **1.2655** | — | — | 0 | 682s/bench | | New 5/10. |
-| 11 | "William Zhang" | **1.2767** | — | — | 0 | 259s/bench | | Resubmitted 5/2 (was "Convex Optimization", verified 1.4556). Blocked on missing `casadi` module. |
-| 12 | "RoRa" | **1.2788** | 0.9577 | 1.6222 | 0 | 2.6h total | :white_check_mark: | Verified 1.2788 (self-reported 1.2723). Resubmitted 5/1. |
-| 13 | "MTK" | **1.2818** | 0.9073 | 1.6529 | 0 | 37s/bench (GPU) | :white_check_mark: | Verified 1.2818 (self-reported 1.317). |
-| 14 | "Electric Beatle" | **1.3253** | — | — | 0 | 2000s/bench (GPU) | | Resubmitted 4/30 (was verified 1.3913). |
-| 15 | "UToronto Analytical" | **1.3323** | 0.9371 | 1.6545 | 0 | 24min total | :white_check_mark: | Verified 1.3323 (self-reported 1.3325). |
-| 16 | "V5" | **1.3382** | — | — | 0 | 850s/bench | | New 4/23. |
-| 17 | "jrslbenn" | **1.353** | — | — | 0 | 750s/bench | | New 5/4. |
-| 18 | "Barsat Khadka" | **1.38** | — | — | 0 | 1000-1800s/bench | | New 5/5. |
-| 19 | "Varun's Parallel Worlds" | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: | |
-| 20 | "UT Austin - AS" | **1.4076** | — | — | 0 | 17s/bench | | |
-| 21 | "ByteDancer" | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: | |
-| 22 | "TAISPlAce" | **1.4321** | — | — | 0 | 28min/bench | | |
-| 23 | "Two-IIITK-Kids" | **1.436** | — | — | 0 | 38min/bench | | New 5/2, resubmitted 5/4. |
-| 24 | "Pragnay" | **1.4427** | — | — | 0 | 632s/bench | | Blocked on `compute_proxy_cost(..., plc=None)` in fallback path. |
-| 25 | "No Man's Sky" | **1.4445** | — | — | 0 | 8.8min/bench | | New 5/4, resubmitted 5/6. |
-| 26 | "Aegir" | **1.4553** | — | — | 0 | 104s/bench | | New 5/9. |
-| 27 | "another Waterloo kid" | **1.4568** | — | — | 0 | 118s/bench | | Blocked on Modal cloud dispatch — can't run air-gapped. |
+| 1 | "Carrotato" | **0.9671** | — | — | 0 | 3.8min/bench | | New 5/12. Triton kernels + Xplace + polish. |
+| 2 | "Shoom" | **0.978** | — | — | 0 | 55min/bench | | Resubmitted 5/12 with new repo + "MultiDREAMPlace" (DREAMPlace + CD refinement). Previous variant verified 1.4901 (bundled DREAMPlace NumPy-2 incompat, fallback only). |
+| 3 | "vmallela" | **1.0109** | 0.7644 | 1.2921 | 0 | 15.5h total | :white_check_mark: | Verified 1.0109 (self-reported 1.1) |
+| 4 | "DREAMPlaceProMaxUltra" | **1.0121** | 0.7955 | 1.2167 | 0 | 6h total | :white_check_mark: | Verified 1.0121 (self-reported 1.0467). Built and ran from team-provided `Dockerfile`. |
+| 5 | "Cezar" | **1.037** | — | — | 0 | 4h total | | Resubmitted 5/11 — team reports finding the bug behind prior local/repo mismatch. Now ships team-provided `Dockerfile`. Previous variant verified 1.1893 (same self-report 1.037). |
+| 6 | "thinkorplace" | **1.0771** | — | — | 0 | 52min/bench | | New 5/13. Cascading Saddle Escape (coord descent + LNS + SA + Hessian saddle escape). |
+| 7 | "Vibe" | **1.1477** | — | — | 0 | 13851s total | | New 5/7. |
+| 8 | "JonaU" | **1.1524** | — | — | 0 | 55min/bench | | New 5/13. SoftSwap (coord descent + adaptive push-apart). |
+| 9 | "Archgen" | **1.16511** | — | — | 0 | 3343s/bench | | Resubmitted 5/9 (was 1.3479). |
+| 10 | "ArzunPD" | **1.1883** | — | — | 0 | 55min/bench | | Resubmitted 5/8 (was 1.2478). |
+| 11 | "Talyxion" | **1.2075** | — | — | 0 | 7.2min/bench | | New 5/10. |
+| 12 | "KLA MACH" | **1.2121** | 0.8527 | 1.6532 | 0 | 2h15min total | :white_check_mark: | Verified 1.2121 (self-reported 1.2355). Consolidates UTDA / Chuanqi Chen / KLA MACH submissions (one algorithm per team). |
+| 13 | "Hoop Dreams" | **1.2207** | 0.8972 | 1.5072 | 0 | 5h total | :white_check_mark: | Verified 1.2207 (self-reported 1.2206). Built and ran from team-provided `Dockerfile`. |
+| 14 | "Adam_A" | **1.2655** | — | — | 0 | 682s/bench | | New 5/10. |
+| 15 | "The Basin Jumpers" | **1.2748** | — | — | 0 | 900s/bench | | Resubmitted 5/13 by William Zhang + Leon Do (was "William Zhang" / "Convex Optimization", verified 1.4556; prior self-report 1.2767 was blocked on missing `casadi` module). |
+| 16 | "RoRa" | **1.2788** | 0.9577 | 1.6222 | 0 | 2.6h total | :white_check_mark: | Verified 1.2788 (self-reported 1.2723). Resubmitted 5/1. |
+| 17 | "MTK" | **1.2818** | 0.9073 | 1.6529 | 0 | 37s/bench (GPU) | :white_check_mark: | Verified 1.2818 (self-reported 1.317). |
+| 18 | "Electric Beatle" | **1.3253** | — | — | 0 | 2000s/bench (GPU) | | Resubmitted 4/30 (was verified 1.3913). |
+| 19 | "UToronto Analytical" | **1.3323** | 0.9371 | 1.6545 | 0 | 24min total | :white_check_mark: | Verified 1.3323 (self-reported 1.3325). |
+| 20 | "V5" | **1.3382** | — | — | 0 | 850s/bench | | New 4/23. |
+| 21 | "jrslbenn" | **1.353** | — | — | 0 | 750s/bench | | New 5/4. |
+| 22 | "Barsat Khadka" | **1.38** | — | — | 0 | 1000-1800s/bench | | New 5/5. |
+| 23 | "Varun's Parallel Worlds" | **1.4017** | 1.0362 | 1.7298 | 0 | 27s/bench | :white_check_mark: | |
+| 24 | "UT Austin - AS" | **1.4076** | — | — | 0 | 17s/bench | | |
+| 25 | "ByteDancer" | **1.4151** | 1.0236 | 1.7792 | 0 | 38min/bench | :white_check_mark: | |
+| 26 | "TAISPlAce" | **1.4321** | — | — | 0 | 28min/bench | | |
+| 27 | "Two-IIITK-Kids" | **1.436** | — | — | 0 | 38min/bench | | New 5/2, resubmitted 5/4. |
+| 28 | "Pragnay" | **1.4427** | — | — | 0 | 632s/bench | | Blocked on `compute_proxy_cost(..., plc=None)` in fallback path. |
+| 29 | "No Man's Sky" | **1.4445** | — | — | 0 | 8.8min/bench | | New 5/4, resubmitted 5/6. |
+| 30 | "Aegir" | **1.4553** | — | — | 0 | 104s/bench | | New 5/9. |
+| 31 | "another Waterloo kid" | **1.4568** | — | — | 0 | 118s/bench | | Blocked on Modal cloud dispatch — can't run air-gapped. |
 | — | RePlAce (baseline) | **1.4578** | 0.9976 | 1.8370 | 0 | — | :white_check_mark: | |
-| 28 | "W3 Solutions" | **1.4824** | — | — | 0 | 90s/bench | | Runtime exceeds 1h/bench cap. |
-| 29 | "Shoom" | **1.4901** | 1.1111 | 1.7884 | 0 | 12h total | :white_check_mark: | Verified 1.4901 (self-reported 1.2353). Bundled DREAMPlace incompatible with NumPy 2.0 (`np.string_` removed); ran fallback SA only. |
-| 30 | "Jiangban Ya" | **1.4943** | 1.0891 | 1.8099 | 0 | 49s/bench | :white_check_mark: | |
-| 31 | "UTAUSTIN-CT" | **1.5062** | 1.1363 | 1.7941 | 0 | 6s/bench | :white_check_mark: | |
-| 32 | "oracleX" | **1.5130** | 1.1340 | 1.7937 | 0 | 11s/bench | :white_check_mark: | |
-| 33 | "SEVmakers" | **1.5200** | — | — | 0 | 200s/bench | | Private repo — pending judge access. |
-| 34 | "CA" | **1.5247** | 1.2226 | 1.7945 | 0 | 2s/bench | :white_check_mark: | Verified 1.5247 (self-reported 1.5238). |
-| 35 | "ZeroLatency" | **1.5286** | — | — | 0 | 17s total | | New 5/9. |
-| 36 | "#5 ubc cpen student" | **1.5337** | 1.1411 | 1.8084 | 0 | 13s/bench | :white_check_mark: | |
-| 37 | Will Seed (Partcl) | **1.5338** | 1.1625 | 1.7965 | 0 | 35s total | :white_check_mark: | |
-| 38 | "RUDY Can't Fail" | **1.5397** | 1.1927 | 1.8881 | 0 | 6min total | :white_check_mark: | Verified 1.5397 (self-reported 1.3605). |
-| 39 | "UT Austin - RH" | **1.6037** | — | — | 0 | 4.5s/bench | | |
-| 40 | "Binghamton" | **1.7621** | — | — | 0 | 2min/bench | | New 5/10. |
-| 41 | "UT Austin - CT" | **1.8706** | — | — | 0 | 187s/bench | | |
-| 42 | "rpocevi" | **1.8894** | — | — | 0 | 22.5s/bench | | New 5/9. |
-| 43 | "AS" | **1.9121** | 1.4614 | 2.3508 | 0 | 0.16s total | :white_check_mark: | |
-| 44 | "Adi's Team" | **2.0025** | — | — | 0 | 3726s/bench | | Blocked on `compute_proxy_cost(skip_congestion=True)` kwarg. |
-| 45 | "Sharc #1" | **2.0433** | 1.5143 | 2.4336 | 0 | 96s/bench | :white_check_mark: | |
+| 32 | "W3 Solutions" | **1.4824** | — | — | 0 | 90s/bench | | Runtime exceeds 1h/bench cap. |
+| 33 | "Jiangban Ya" | **1.4943** | 1.0891 | 1.8099 | 0 | 49s/bench | :white_check_mark: | |
+| 34 | "UTAUSTIN-CT" | **1.5062** | 1.1363 | 1.7941 | 0 | 6s/bench | :white_check_mark: | |
+| 35 | "oracleX" | **1.5130** | 1.1340 | 1.7937 | 0 | 11s/bench | :white_check_mark: | |
+| 36 | "SEVmakers" | **1.5200** | — | — | 0 | 200s/bench | | Private repo — pending judge access. |
+| 37 | "CA" | **1.5247** | 1.2226 | 1.7945 | 0 | 2s/bench | :white_check_mark: | Verified 1.5247 (self-reported 1.5238). |
+| 38 | "ZeroLatency" | **1.5286** | — | — | 0 | 17s total | | New 5/9. |
+| 39 | "#5 ubc cpen student" | **1.5337** | 1.1411 | 1.8084 | 0 | 13s/bench | :white_check_mark: | |
+| 40 | Will Seed (Partcl) | **1.5338** | 1.1625 | 1.7965 | 0 | 35s total | :white_check_mark: | |
+| 41 | "RUDY Can't Fail" | **1.5397** | 1.1927 | 1.8881 | 0 | 6min total | :white_check_mark: | Verified 1.5397 (self-reported 1.3605). |
+| 42 | "UT Austin - RH" | **1.6037** | — | — | 0 | 4.5s/bench | | |
+| 43 | "Binghamton" | **1.7621** | — | — | 0 | 2min/bench | | New 5/10. Team also reports 1.5375 from feeding feng-shui fixed-macro locations to DREAMPlace for soft macros (not legalized). |
+| 44 | "UT Austin - CT" | **1.8706** | — | — | 0 | 187s/bench | | |
+| 45 | "rpocevi" | **1.8894** | — | — | 0 | 22.5s/bench | | New 5/9. |
+| 46 | "AS" | **1.9121** | 1.4614 | 2.3508 | 0 | 0.16s total | :white_check_mark: | |
+| 47 | "Adi's Team" | **2.0025** | — | — | 0 | 3726s/bench | | Blocked on `compute_proxy_cost(skip_congestion=True)` kwarg. |
+| 48 | "Sharc #1" | **2.0433** | 1.5143 | 2.4336 | 0 | 96s/bench | :white_check_mark: | |
 | — | SA (baseline) | 2.1251 | 1.3166 | 3.6726 | 0 | — | :white_check_mark: | |
 | — | Greedy Row (demo) | 2.2109 | 1.6728 | 2.7696 | 0 | 0.3s total | :white_check_mark: | |
 | — | "MacroBio" | pending | — | — | — | — | | |


### PR DESCRIPTION
## Summary

**New (unverified):**
- **#1 Carrotato** (0.9671) — Triton kernels + Xplace + polish
- **#6 thinkorplace** (1.0771) — Cascading Saddle Escape (coord descent + LNS + SA + Hessian saddle escape)
- **#8 JonaU** (1.1524) — SoftSwap (coord descent + adaptive push-apart)

**Resubmits (drop verified mark, score updated to new self-report per convention):**
- **#5 Cezar v4** (1.037, was verified 1.1893) — team reports finding the bug behind the prior local/repo score mismatch. Now ships team-provided Dockerfile.
- **#2 Shoom v17** (0.978, was verified 1.4901) — new repo + new algorithm ("MultiDREAMPlace": DREAMPlace + CD refinement). Prior variant had NumPy-2 incompat in bundled DREAMPlace, fell back to SA only.
- **#15 The Basin Jumpers** (1.2748, was "William Zhang" / "Convex Optimization", verified 1.4556) — DREAMPlace + RePlAce; replaces casadi-blocked entry.

Binghamton note also refreshed with their reported 1.5375 fs→dp variant.

## Follow-up
Next: work down the top unverified entries (Carrotato, Shoom v17, Cezar v4, Vibe, Archgen, ArzunPD, Talyxion, thinkorplace, JonaU, Adam_A, The Basin Jumpers).

## Test plan
- [x] All ranks renumber consistently
- [x] Resubmit notes mention prior verified score
- [x] No verified ✓ on entries whose code changed since last eval

🤖 Generated with [Claude Code](https://claude.com/claude-code)