### PR TITLE
Verify Vibe (1.1443) — confirmed rank #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 |------|------|---------------|------|-------|----------|---------|----------|-------|
 | 1 | "vmallela" | **1.0109** | 0.7644 | 1.2921 | 0 | 15.5h total | :white_check_mark: | Verified 1.0109 (self-reported 1.1) |
 | 2 | "DREAMPlaceProMaxUltra" | **1.0121** | 0.7955 | 1.2167 | 0 | 6h total | :white_check_mark: | Verified 1.0121 (self-reported 1.0467). Built and ran from team-provided `Dockerfile`. |
-| 3 | "Vibe" | **1.1477** | — | — | 0 | 13851s total | | New 5/7. |
+| 3 | "Vibe" | **1.1443** | — | — | 0 | 13851s total | :white_check_mark: | Verified 1.1443 (self-reported 1.1477). |
 | 4 | "Archgen" | **1.16511** | — | — | 0 | 3343s/bench | | Resubmitted 5/9 (was 1.3479). |
 | 5 | "ArzunPD" | **1.1883** | — | — | 0 | 55min/bench | | Resubmitted 5/8 (was 1.2478). |
 | 6 | "Cezar" | **1.1893** | 0.9041 | 1.4379 | 0 | 15.5h total | :white_check_mark: | Verified 1.1893 (self-reported 1.037). Resubmitted 5/3. Previous variant verified 1.2224. |


### PR DESCRIPTION
## Summary

- Ran full evaluation of the \"Vibe\" submission across all 17 IBM benchmarks
- Verified avg proxy cost: **1.1443** (self-reported: 1.1477)
- Zero overlaps on all benchmarks
- +46.2% vs SA baseline, +21.5% vs RePlAce baseline
- Rank #3 confirmed

## Per-benchmark results

| Benchmark | Proxy | vs SA | vs RePlAce |
|-----------|-------|-------|------------|
| ibm01 | 0.9295 | +29.4% | +6.8% |
| ibm02 | 1.0936 | +42.7% | +40.5% |
| ibm03 | 1.0311 | +40.7% | +22.0% |
| ibm04 | 0.9927 | +34.0% | +23.8% |
| ibm06 | 1.2383 | +50.6% | +23.5% |
| ibm07 | 1.0904 | +46.1% | +25.5% |
| ibm08 | 1.1489 | +40.3% | +19.6% |
| ibm09 | 0.8683 | +37.4% | +22.4% |
| ibm10 | 1.1036 | +47.7% | +26.5% |
| ibm11 | 0.9462 | +44.7% | +19.6% |
| ibm12 | 1.2546 | +55.6% | +27.3% |
| ibm13 | 1.0259 | +46.4% | +23.2% |
| ibm14 | 1.3562 | +40.4% | +12.1% |
| ibm15 | 1.2788 | +44.4% | +15.6% |
| ibm16 | 1.3321 | +40.4% | +9.9% |
| ibm17 | 1.4376 | +60.9% | +12.6% |
| ibm18 | 1.3257 | +52.2% | +25.2% |
| **AVG** | **1.1443** | **+46.2%** | **+21.5%** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)