### PR TITLE
Verify Archgen (1.0948) — takes #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,9 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 | 4 | "DREAMPlaceProMaxUltra" | **1.0121** | 0.7955 | 1.2167 | 0 | 6h total | :white_check_mark: | Verified 1.0121 (self-reported 1.0467). Built and ran from team-provided `Dockerfile`. |
 | 5 | "Cezar" | **1.037** | — | — | 0 | 4h total | | Resubmitted 5/11 — team reports finding the bug behind prior local/repo mismatch. Now ships team-provided `Dockerfile`. Previous variant verified 1.1893 (same self-report 1.037). |
 | 6 | "thinkorplace" | **1.0771** | — | — | 0 | 52min/bench | | New 5/13. Cascading Saddle Escape (coord descent + LNS + SA + Hessian saddle escape). |
-| 7 | "Vibe" | **1.1443** | — | — | 0 | 13851s total | :white_check_mark: | Verified 1.1443 (self-reported 1.1477). |
-| 8 | "JonaU" | **1.1524** | — | — | 0 | 55min/bench | | New 5/13. SoftSwap (coord descent + adaptive push-apart). |
-| 9 | "Archgen" | **1.16511** | — | — | 0 | 3343s/bench | | Resubmitted 5/9 (was 1.3479). |
+| 7 | "Archgen" | **1.0948** | 0.7931 | 1.4345 | 0 | 15.25h total | :white_check_mark: | Verified 1.0948 (self-reported 1.16511 — 5.6% BETTER than self-reported). AutoDMP++ analytical placement + multi-stage soft-CD/exact local search. |
+| 8 | "Vibe" | **1.1443** | — | — | 0 | 13851s total | :white_check_mark: | Verified 1.1443 (self-reported 1.1477). |
+| 9 | "JonaU" | **1.1524** | — | — | 0 | 55min/bench | | New 5/13. SoftSwap (coord descent + adaptive push-apart). |
 | 10 | "KLA MACH" | **1.1764** | — | — | 0 | 15min/bench | | Resubmitted 5/14 as "ProxyCD" (DREAMPlace + parallel CD/SA + ILS). Previous algorithm verified 1.2121 (self-reported 1.2355). Consolidates UTDA / Chuanqi Chen / KLA MACH submissions (one algo per team). |
 | 11 | "ArzunPD" | **1.1883** | — | — | 0 | 55min/bench | | Resubmitted 5/8 (was 1.2478). |
 | 12 | "Talyxion" | **1.2075** | — | — | 0 | 7.2min/bench | | New 5/10. |


### PR DESCRIPTION
## Summary

Verified Archgen's `submission_4.py` (AutoDMP++) across all 17 IBM benchmarks.

- **Verified avg proxy: 1.0948** (self-reported 1.16511 — 5.6% **better** than self-reported)
- 0 overlaps across all benchmarks
- Best `ibm01` = 0.7931, worst `ibm17` = 1.4345
- Total runtime: 54902s (~15.25h, ~3229s/bench avg)
- Ran inside `eval_docker/Dockerfile` (pytorch 2.5.1 / cuda 12.4 / py3.11) — local uv (pytorch 2.10 / py3.12) hit `CUBLAS_STATUS_INVALID_VALUE` in the team's bundled placer's `_contest_density_surrogate` einsum, so we used the standard judges' image.

## Leaderboard impact

Archgen moves from rank 9 (self-reported 1.16511) → rank 7 (verified 1.0948), displacing Vibe → 8 and JonaU → 9.

## Per-benchmark scores

| Bench | Proxy | vs SA | vs RePlAce |
|---|---|---|---|
| ibm01 | 0.7931 | +39.8% | +20.5% |
| ibm02 | 1.0574 | +44.6% | +42.4% |
| ibm03 | 0.9251 | +46.8% | +30.0% |
| ibm04 | 0.9782 | +34.9% | +24.9% |
| ibm06 | 1.1149 | +55.5% | +31.1% |
| ibm07 | 1.0923 | +46.0% | +25.4% |
| ibm08 | 1.1049 | +42.6% | +22.7% |
| ibm09 | 0.8418 | +39.3% | +24.8% |
| ibm10 | 1.0718 | +49.2% | +28.6% |
| ibm11 | 0.8872 | +48.1% | +24.6% |
| ibm12 | 1.3084 | +53.7% | +24.2% |
| ibm13 | 0.9863 | +48.5% | +26.1% |
| ibm14 | 1.2588 | +44.7% | +18.5% |
| ibm15 | 1.2106 | +47.4% | +20.1% |
| ibm16 | 1.1736 | +47.5% | +20.6% |
| ibm17 | 1.4345 | +60.9% | +12.8% |
| ibm18 | 1.3727 | +50.5% | +22.5% |
| **AVG** | **1.0948** | **+48.5%** | **+24.9%** |

## Test plan
- [ ] Render README on GitHub, confirm rank 7 row reads correctly
- [ ] Spot-check ranks are monotonic by Avg Proxy Cost across the top 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)