### PR TITLE
Make MIN_GAP configurable via ORFS_MIN_GAP_UM

### DIFF
--- a/scripts/generate_macro_placement_tcl.py
+++ b/scripts/generate_macro_placement_tcl.py
@@ -9,6 +9,7 @@ Usage:
     python scripts/generate_macro_placement_tcl.py --benchmark ariane133
 """
 
+import os
 import re
 import sys
 import argparse
@@ -259,8 +260,19 @@ def write_orfs_macro_placement(placement, benchmark, plc, output_file, core_area
     # PDN metal5 needs ~10μm channels between macros.
     # NOTE: this modifies the submitted placement at Tier 2. A sidecar diff file
     # is written so teams can see exactly what the evaluator pushed and by how much.
-    if core_area is not None:
+    #
+    # MIN_GAP is configurable via the ORFS_MIN_GAP_UM env var. Default 12μm is
+    # the safe baseline. B2B / abutted-cluster placements may set this to 0
+    # (or any value <= 0) to disable the push entirely; in that case the
+    # placer is fully responsible for spacing and PDN routability.
+    try:
+        MIN_GAP = float(os.environ.get('ORFS_MIN_GAP_UM', '12.0'))
+    except ValueError:
         MIN_GAP = 12.0
+    if core_area is not None and MIN_GAP <= 0:
+        print(f"  ORFS_MIN_GAP_UM={MIN_GAP} — spacing push disabled, "
+              f"placer owns spacing and PDN routability")
+    if core_area is not None and MIN_GAP > 0:
         # Collect all placements into a flat list for gap enforcement.
         # Each entry: (kind, key1, key2, x, y, w, h, macro_name)
         _all = []


### PR DESCRIPTION
## Summary

- Adds an `ORFS_MIN_GAP_UM` env var to control the macro spacing push in the TCL emitter (`scripts/generate_macro_placement_tcl.py`).
- Default behavior unchanged: `12.0μm` when the var is unset, empty, or malformed.
- Setting to `0` (or any non-positive value) skips the push entirely. The placer then owns spacing and PDN routability — consistent with the SCORING.md contract.
- Logs a one-line message when the push is skipped so the override is visible in eval output.

## Motivation

Contest feedback (Billy / palacedeforsaken@gmail.com) made two related points about the hardcoded 12μm push:

1. **Contract**: SCORING.md says *"The placer is responsible for zero overlaps, staying within canvas bounds, macro orientation choices, and any other decisions that affect downstream ORFS routability."* The auto-push contradicts this for B2B / abutted-cluster strategies that are standard in commercial EDA tools.
2. **Strap geometry**: NG45 M4 pitch is 56μm. The 12μm push falls between zero and one strap pitch — too narrow for a strap to land, wide enough to trigger PDN's channel-repair logic, which then fails. His reproducer shows PDN-0178 channels at exactly the 12–14μm widths the push creates, while the same B2B placement with `MIN_GAP=0` passes PDN end-to-end.

Rather than change the default (which would invalidate the spacing assumption of existing submissions), this makes the value opt-in.

## How it works

```python
MIN_GAP = float(os.environ.get('ORFS_MIN_GAP_UM', '12.0'))
...
if core_area is not None and MIN_GAP > 0:
    # push apart loop (unchanged)
```

Smoke-tested env parsing covers `12.0` (default), `0` / `0.0` (skip), `28` (wider), `bogus` / `''` / unset (falls back to 12.0).

## Test plan

- [ ] Run `evaluate_with_orfs.py` on ariane133_ng45 without the env var → identical behavior to main (`12μm` push as before).
- [ ] Run with `ORFS_MIN_GAP_UM=0` on a known-overlap-free B2B placement → no push applied, `place_macros.tcl.spacing_diff.txt` is not produced, eval log shows skip message.
- [ ] Run with `ORFS_MIN_GAP_UM=28` (>=M4 pitch / 2) → push applied at wider gap, sidecar diff reflects the new threshold.
- [ ] Confirm Billy's seed-4 B2B placement now passes PDN under `ORFS_MIN_GAP_UM=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)