### PR TITLE
Fix README: 17 IBM benchmarks (no ibm05), not 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Evaluation is two-tiered:
 
 ### Tier 1: Proxy Cost Ranking (All Submissions)
 
-All submissions are ranked by **proxy cost** across the 18 IBM benchmarks. This is the primary qualifying metric. Proxy cost is computed using the TILOS MacroPlacement evaluator:
+All submissions are ranked by **proxy cost** across the 17 IBM benchmarks (ibm01–ibm04, ibm06–ibm18). This is the primary qualifying metric. Proxy cost is computed using the TILOS MacroPlacement evaluator:
 
 > **Proxy Cost = 1.0 × Wirelength + 0.5 × Density + 0.5 × Congestion**
 


### PR DESCRIPTION
## Summary

- README.md line 102 said "18 IBM benchmarks" while every other reference in the same file (lines 142, 230, 297, 303) correctly says 17.
- The ICCAD04 suite skips ibm05. The actual set is ibm01–ibm04 and ibm06–ibm18 — confirmed against `external/MacroPlacement/Testcases/ICCAD04/` directory listing and `SETUP.md:218-219` benchmark list.
- Also makes the range explicit so this doesn't get miscounted again.

Reported by Shreyash.

## Test plan

- [ ] Visual diff: only the Tier 1 description line changes; no other content affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)