### PR TITLE
Verify Talyxion (1.1528) — takes #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ Submissions are ranked by **average proxy cost** across all 17 IBM benchmarks (l
 | 11 | "Archgen" | **1.0948** | 0.7931 | 1.4345 | 0 | 15.25h total | :white_check_mark: | Verified 1.0948 (self-reported 1.16511 — 5.6% BETTER than self-reported). |
 | 12 | "Vibe" | **1.1443** | — | — | 0 | 13851s total | :white_check_mark: | Verified 1.1443 (self-reported 1.1477). |
 | 13 | "JonaU" | **1.1524** | — | — | 0 | 55min/bench | | New 5/13. (Jona Uhe) |
-| 14 | "ArzunPD" | **1.1883** | — | — | 0 | 55min/bench | | Resubmitted 5/8 (was 1.2478). |
-| 15 | "Talyxion" | **1.2075** | — | — | 0 | 7.2min/bench | | New 5/10. |
+| 14 | "Talyxion" | **1.1528** | 0.8664 | 1.4974 | 0 | 6.35h total | :white_check_mark: | Verified 1.1528 (current main self-reports 1.1531; form submission was 1.2075 — team iterated to v21 numgrad+CD/swap polish on v5 analytical base post-form-submit). |
+| 15 | "ArzunPD" | **1.1883** | — | — | 0 | 55min/bench | | Resubmitted 5/8 (was 1.2478). |
 | 16 | "Hoop Dreams" | **1.2207** | 0.8972 | 1.5072 | 0 | 5h total | :white_check_mark: | Verified 1.2207 (self-reported 1.2206). Built and ran from team-provided `Dockerfile`. |
 | 17 | "MakerCode" | **1.2282** | — | — | 0 | ~55min/bench | | Resubmitted 5/16 (v2). Was 1.26. (Wei Yet Ng) |
 | 18 | "KKPlace" | **1.2451** | — | — | 0 | 55min/bench | | New 5/13. (Kenneth Hou) |


### PR DESCRIPTION
## Summary

Verified Talyxion's current `placer.py` (HybridV21) across all 17 IBM benchmarks.

- **Verified avg proxy: 1.1528** (team's current main self-reports **1.1531** — within 0.0003)
- Original form submission was **1.2075** at 7.2min/bench; team has iterated post-form-submit to v21 (numerical-gradient descent on exact fast proxy + CD/swap polish, on v-x-zhang's v5 analytical base).
- 0 overlaps, 17/17 VALID
- Best `ibm01` = 0.8664, worst `ibm18` = 1.4974
- Total runtime: 22882s (~6.35h, ~22min/bench avg)
- Ran air-gapped in `challenge-eval` Docker (pytorch 2.5.1 / py3.11) with `submissions/` mounted RO so the placer's sibling import of `submissions/vxzhang/v5_rudy_w1_placer.py` resolves.
- Limits: `--network none --memory 64g --cpus 16 --gpus all`.

## Leaderboard impact

Talyxion moves from rank 15 (self-reported 1.2075) → rank 14 (verified 1.1528), between JonaU (1.1524) and ArzunPD. ArzunPD demoted 14 → 15.

## Per-benchmark scores

| Bench | Proxy | vs SA | vs RePlAce |
|---|---|---|---|
| ibm01 | 0.8664 | +34.2% | +13.2% |
| ibm02 | 1.2046 | +36.8% | +34.4% |
| ibm03 | 1.0518 | +39.6% | +20.4% |
| ibm04 | 1.0454 | +30.5% | +19.7% |
| ibm06 | 1.2697 | +49.3% | +21.6% |
| ibm07 | 1.1797 | +41.7% | +19.4% |
| ibm08 | 1.2039 | +37.4% | +15.7% |
| ibm09 | 0.8816 | +36.5% | +21.2% |
| ibm10 | 1.0389 | +50.8% | +30.8% |
| ibm11 | 0.8813 | +48.5% | +25.1% |
| ibm12 | 1.3593 | +51.9% | +21.3% |
| ibm13 | 0.9802 | +48.8% | +26.6% |
| ibm14 | 1.2320 | +45.8% | +20.2% |
| ibm15 | 1.3340 | +42.0% | +12.0% |
| ibm16 | 1.1761 | +47.3% | +20.4% |
| ibm17 | 1.3953 | +62.0% | +15.2% |
| ibm18 | 1.4974 | +46.0% | +15.5% |
| **AVG** | **1.1528** | **+45.8%** | **+20.9%** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)